### PR TITLE
fix: Fix display of Portlets having loaded its JS using JavascriptManager - MEED-5942 - Meeds-io/MIPs#120

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-layout-components/js/ApplicationUtils.js
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout-components/js/ApplicationUtils.js
@@ -33,14 +33,12 @@ export function installApplication(navUri, applicationStorageId, applicationElem
     .then(applicationContent => handleApplicationContent(applicationContent, applicationElement, applicationMode));
 }
 
-function handleApplicationContent(applicationContent, applicationElement, applicationMode) {
+function handleApplicationContent(applicationContent, applicationElement) {
   const newHeadContent = applicationContent.substring(applicationContent.search('<head') + applicationContent.match(/<head.*>/g)[0].length, applicationContent.search('</head>'));
   let newBodyContent = applicationContent.substring(applicationContent.search('<body') + applicationContent.match(/<body.*>/g)[0].length, applicationContent.lastIndexOf('</body>'));
   newBodyContent = installNewCSS(newHeadContent, newBodyContent);
   installNewJS(newHeadContent);
-  if (applicationMode === 'EDIT') {
-    installNewJS(newBodyContent, 'jsManager', true);
-  }
+  installNewJS(newBodyContent, 'jsManager', true);
 
   const newHtmlDocument = document.createElement('div');
   newHtmlDocument.innerHTML = newBodyContent;
@@ -112,7 +110,6 @@ function installNewJS(scriptsContent, specificId, forceReload) {
       }
       scriptElement.innerText = scriptContent.substring(scriptContent.indexOf('>') + 1).replace(/(\r)?(\n)?/g, '');
       document.head.append(scriptElement);
-      replaceScriptElements(scriptElement);
     }
     scriptIteratorElement = replacableScriptsIterator.next().value;
   }


### PR DESCRIPTION
Prior to this change, the JS loaded by portlet rendering phase using `JavascriptManager` isn't interpreted. This change ensures to interpret `jsManager` content each time a portlet is loaded through fetch.