### PR TITLE
feat: Add icon in Grid Section Cells for better UX - MEED-5652 - Meeds-io/MIPs#120

### DIFF
--- a/layout-webapp/src/main/resources/locale/portlet/LayoutEditor_en.properties
+++ b/layout-webapp/src/main/resources/locale/portlet/LayoutEditor_en.properties
@@ -85,3 +85,4 @@ layout.templateDescriptionDrawerTitle=Description of page template
 layout.errorUploadingPreview=An error occurred while uploading Illustration. Please contact the administrator or try again later.
 layout.uploadPreviewTitle=Upload an illustration for page template
 layout.pageTemplateCreatedSuccessfully=Page template created successfully
+layout.cellHoverTooltip=Drag mouse to select a zone or click to add an application

--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/components/content/container/Cell.vue
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/components/content/container/Cell.vue
@@ -76,9 +76,11 @@
             'grey-background': !isSelectedCell && !hoverScope.hover && (!$root.movingCell || $root.selectedSectionId !== parentId),
             'light-grey-background': !isSelectedCell && hoverScope.hover && (!$root.movingCell || $root.selectedSectionId !== parentId),
             'transparent': $root.movingCell && $root.selectedSectionId === parentId && !isSelectedCell,
+            'crosshair-cursor': !isDynamicSection,
             'grey': isSelectedCell,
             'invisible': moving,
           }"
+          :title="!isDynamicSection && $t('layout.cellHoverTooltip')"
           class="full-width"
           flat
           v-on="!multiSelectEnabled && {
@@ -101,6 +103,14 @@
               <span class="text-no-wrap">{{ $t('layout.addApp') }}</span>
             </div>
           </v-card>
+          <div
+            v-else
+            :aria-label="$t('layout.cellHoverTooltip')"
+            class="d-flex align-center justify-center full-width full-height">
+            <v-icon
+              class="icon-default-color"
+              size="20">fa-vector-square</v-icon>
+          </div>
         </v-card>
       </v-hover>
     </template>


### PR DESCRIPTION
This change will add an icon and a tooltip in the center of cells to let user know that it can drag or click on cell to add application in a selected zone.