### PR TITLE
fix: Fix Site and Page permissions - MEED-6274 - Meeds-io/MIPs#120

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/model/PermissionUpdateModel.java
+++ b/layout-service/src/main/java/io/meeds/layout/model/PermissionUpdateModel.java
@@ -18,6 +18,8 @@
  */
 package io.meeds.layout.model;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,15 +29,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PermissionUpdateModel {
 
-  private String siteType;
+  private String       siteType;
 
-  private String siteName;
+  private String       siteName;
 
-  private String accessPermissions;
+  private List<String> accessPermissions;
 
-  private String editPermission;
+  private String       editPermission;
 
-  public PermissionUpdateModel(String accessPermissions, String editPermission) {
+  public PermissionUpdateModel(List<String> accessPermissions, String editPermission) {
     this.accessPermissions = accessPermissions;
     this.editPermission = editPermission;
   }

--- a/layout-service/src/main/java/io/meeds/layout/service/PageLayoutService.java
+++ b/layout-service/src/main/java/io/meeds/layout/service/PageLayoutService.java
@@ -247,11 +247,7 @@ public class PageLayoutService {
       throw new IllegalAccessException();
     }
     PageState pageState = pageContext.getState();
-    List<String> accessPermissionsList = List.of(permissionUpdateModel.getAccessPermissions().split(","))
-                                             .stream()
-                                             .map(String::trim)
-                                             .distinct()
-                                             .toList();
+    List<String> accessPermissionsList = permissionUpdateModel.getAccessPermissions();
     String editPermission = permissionUpdateModel.getEditPermission();
 
     pageContext.setState(new PageState(pageState.getDisplayName(),

--- a/layout-service/src/main/java/io/meeds/layout/service/SiteLayoutService.java
+++ b/layout-service/src/main/java/io/meeds/layout/service/SiteLayoutService.java
@@ -18,8 +18,6 @@
  */
 package io.meeds.layout.service;
 
-import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -71,7 +69,7 @@ public class SiteLayoutService {
 
   @SneakyThrows
   public PortalConfig createSite(SiteCreateModel createModel, String username) throws IllegalAccessException,
-                                                                       ObjectAlreadyExistsException {
+                                                                               ObjectAlreadyExistsException {
     if (!aclService.canAddSite(username)) {
       throw new IllegalAccessException();
     } else if (layoutService.getPortalConfig(createModel.getPortalConfig().getName()) != null) {
@@ -104,7 +102,7 @@ public class SiteLayoutService {
   }
 
   public void updateSite(SiteUpdateModel updateModel, String username) throws IllegalAccessException,
-                                                                                        ObjectNotFoundException {
+                                                                       ObjectNotFoundException {
     SiteKey siteKey = new SiteKey(updateModel.getSiteType(), updateModel.getSiteName());
     PortalConfig portalConfig = layoutService.getPortalConfig(siteKey);
     if (portalConfig == null) {
@@ -149,12 +147,8 @@ public class SiteLayoutService {
     if (!StringUtils.isBlank(permissionUpdateModel.getEditPermission())) {
       portalConfig.setEditPermission(permissionUpdateModel.getEditPermission());
     }
-    if (!StringUtils.isBlank(permissionUpdateModel.getAccessPermissions())) {
-      String[] accessPermissions = List.of(permissionUpdateModel.getAccessPermissions().split(","))
-                                       .stream()
-                                       .distinct()
-                                       .toArray(String[]::new);
-      portalConfig.setAccessPermissions(accessPermissions);
+    if (permissionUpdateModel.getAccessPermissions() != null) {
+      portalConfig.setAccessPermissions(permissionUpdateModel.getAccessPermissions().toArray(new String[0]));
     }
     layoutService.save(portalConfig);
   }

--- a/layout-service/src/test/java/io/meeds/layout/service/PageLayoutServiceTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/service/PageLayoutServiceTest.java
@@ -294,7 +294,7 @@ public class PageLayoutServiceTest {
 
   @Test
   public void updatePagePermissions() throws IllegalAccessException, ObjectNotFoundException {
-    String accessPermissions = "access, permissions";
+    List<String> accessPermissions = Arrays.asList("access", "permissions");
     String editPermission = "edit permission";
     PermissionUpdateModel permissionModel = new PermissionUpdateModel(accessPermissions, editPermission);
     assertThrows(ObjectNotFoundException.class,

--- a/layout-service/src/test/java/io/meeds/layout/service/SiteLayoutServiceTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/service/SiteLayoutServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -201,7 +202,7 @@ public class SiteLayoutServiceTest {
   @Test
   @SneakyThrows
   public void updateSitePermissions() {
-    String accessPermissions = "access, permissions";
+    List<String> accessPermissions = Arrays.asList("access", "permissions");
     String editPermission = "edit permission";
     PermissionUpdateModel permissionModel = new PermissionUpdateModel(SITE_KEY.getTypeName(),
                                                                       SITE_KEY.getName(),

--- a/layout-webapp/src/main/webapp/vue-app/common-layout-components/js/PageLayoutService.js
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout-components/js/PageLayoutService.js
@@ -111,8 +111,8 @@ export function updatePagePermissions(pageRef, editPermission, accessPermissions
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      editPermission,
-      accessPermissions,
+      editPermission: editPermission || null,
+      accessPermissions: accessPermissions || null,
     }),
   }).then((resp) => {
     if (!resp?.ok) {


### PR DESCRIPTION
Prior to this change, the site and pages permissions update was using a String that is concatenating multiple permissions using commar. This change ensures to use the right Model Object parsing in REST endpoint to be able to handle a list of permissions instead.