### PR TITLE
fix: Fix Page with link creation - MEED-6870 - Meeds-io/meeds#1994

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-layout-components/js/PageLayoutService.js
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout-components/js/PageLayoutService.js
@@ -69,7 +69,7 @@ export function createPage(pageName, pageTitle, pageSiteName, pageSiteType, page
     },
     body: JSON.stringify({
       pageName,
-      pageTemplateId,
+      pageTemplateId: pageTemplateId || 0,
       pageType,
       pageTitle,
       pageSiteType,


### PR DESCRIPTION
Prior to this change, the page link creation sends an HTTP 400 error due to having a boolean (false) instead of a long (0). This change ensures to use '0' systematically when the attribute 'pageTemplateId' is falsy.