### PR TITLE
fix: Fix SNV Editor Back Url - MEED-6937 - Meeds-io/meeds#2060

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/main.js
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/main.js
@@ -88,6 +88,7 @@ export function init() {
           diffScrollX: 0,
           diffScrollY: 0,
           gap: 20,
+          nodeUri: null,
         }),
         computed: {
           parentAppX() {
@@ -127,6 +128,11 @@ export function init() {
               this.$root.$emit('layout-editor-moving-start', this.movingParentId);
             } else {
               this.$root.$emit('layout-editor-moving-end', this.movingParentId);
+            }
+          },
+          nodeUri() {
+            if (this.nodeUri) {
+              eXo.env.portal.webPageUrl = `/portal${this.nodeUri}`;
             }
           },
           layout(newVal, oldVal) {


### PR DESCRIPTION
Prior to this change, when editing SNV in full edit mode (with a new page opened in a new tab) and then the user publishes the SNV content, the SNV redirects to the previous page which is the Layout Editor. When the layout editor is opened again in a new Tab, a new draft page is opened and makes the first Tab with Layout editor in an invalid state. This change will avoid redirection to layout editor when publishing the SNV by introducing a global variable indicating the page being edited in editor and that should be used for redirection in SNV.