### PR TITLE
feat: Allow to distinguish Portlets ediable through layout - MEED-7033 - Meeds-io/meeds#2121

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/model/PortletDescriptor.java
+++ b/layout-service/src/main/java/io/meeds/layout/model/PortletDescriptor.java
@@ -39,6 +39,8 @@ public class PortletDescriptor {
 
   private List<String> supportedModes;
 
+  private boolean      editable;
+
   public String getContentId() {
     return applicationName + "/" + portletName;
   }

--- a/layout-service/src/main/java/io/meeds/layout/model/PortletInstance.java
+++ b/layout-service/src/main/java/io/meeds/layout/model/PortletInstance.java
@@ -53,4 +53,6 @@ public class PortletInstance {
 
   private boolean                         disabled;
 
+  private boolean                         editable;
+
 }

--- a/layout-service/src/main/java/io/meeds/layout/service/PortletInstanceService.java
+++ b/layout-service/src/main/java/io/meeds/layout/service/PortletInstanceService.java
@@ -41,6 +41,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.LocaleConfigService;
 import org.exoplatform.social.attachment.AttachmentService;
 
+import io.meeds.layout.model.PortletDescriptor;
 import io.meeds.layout.model.PortletInstance;
 import io.meeds.layout.model.PortletInstanceCategory;
 import io.meeds.layout.model.PortletInstancePreference;
@@ -82,6 +83,9 @@ public class PortletInstanceService {
 
   @Autowired
   private PortletInstanceLayoutStorage                 portletInstanceLayoutStorage;
+
+  @Autowired
+  private PortletService                               portletService;
 
   private Map<String, PortletInstancePreferencePlugin> preferencePlugins         = new ConcurrentHashMap<>();
 
@@ -326,6 +330,10 @@ public class PortletInstanceService {
       portletInstance.setIllustrationId(Long.parseLong(attachmentFileIds.get(0)));
     }
     portletInstance.setApplicationId(getPortletInstanceApplicationId(portletInstance.getId()));
+    PortletDescriptor portlet = portletService.getPortlet(portletInstance.getContentId());
+    if (portlet != null) {
+      portletInstance.setEditable(portlet.isEditable());
+    }
   }
 
   private void computePortletInstanceCategoryAttributes(Locale locale, PortletInstanceCategory portletInstanceCategory) {

--- a/layout-service/src/main/java/io/meeds/layout/storage/PortletStorage.java
+++ b/layout-service/src/main/java/io/meeds/layout/storage/PortletStorage.java
@@ -30,6 +30,7 @@ import org.gatein.pc.api.PortletInvoker;
 import org.gatein.pc.api.info.MetaInfo;
 import org.gatein.pc.api.info.ModeInfo;
 import org.gatein.pc.api.info.PortletInfo;
+import org.gatein.pc.portlet.impl.info.ContainerPortletInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -86,8 +87,11 @@ public class PortletStorage {
     portletDescriptor.setName(getLocalizedStringOrDefault(nameLS, info.getName()));
     portletDescriptor.setDescription(getLocalizedStringOrDefault(descriptionLS, info.getName()));
     portletDescriptor.setSupportedModes(allModes.stream()
-                                                .map(m -> m.getModeName())
-                                                .toList());
+                                        .map(m -> m.getModeName())
+                                        .toList());
+    if(info instanceof ContainerPortletInfo containerPortletInfo) {
+      portletDescriptor.setEditable(StringUtils.equals("true", containerPortletInfo.getInitParameter("layout-content-editable")));
+    }
     return portletDescriptor;
   }
 

--- a/layout-service/src/main/java/io/meeds/layout/util/EntityMapper.java
+++ b/layout-service/src/main/java/io/meeds/layout/util/EntityMapper.java
@@ -65,7 +65,8 @@ public class EntityMapper {
                                            entity.getPermissions().stream().filter(StringUtils::isNotBlank).toList(),
                                portlet == null ? null : portlet.getSupportedModes(),
                                entity.isSystem(),
-                               entity.isDisabled());
+                               entity.isDisabled(),
+                               false);
   }
 
   public static PortletInstanceCategoryEntity toEntity(PortletInstanceCategory instance) {

--- a/layout-service/src/test/java/io/meeds/layout/service/PortletInstanceServiceTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/service/PortletInstanceServiceTest.java
@@ -99,6 +99,9 @@ public class PortletInstanceServiceTest {
   @MockBean
   private PortletInstanceStorage          portletInstanceStorage;
 
+  @MockBean
+  private PortletService                  portletService;
+
   @Mock
   private PortletInstanceCategory         portletInstanceCategory;
 
@@ -641,6 +644,7 @@ public class PortletInstanceServiceTest {
                                Collections.singletonList("Everyone"),
                                Collections.singletonList("edit"),
                                true,
+                               false,
                                false);
   }
 

--- a/layout-webapp/src/main/resources/locale/portlet/LayoutEditor_en.properties
+++ b/layout-webapp/src/main/resources/locale/portlet/LayoutEditor_en.properties
@@ -321,3 +321,4 @@ layout.imagePositionBottomRight=Bottom right
 layout.gradient=Gradient
 layout.gradientFrom=From
 layout.gradientTo=To
+layout.readonlyPortletContent=Read Only Portlet Content

--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/components/content/container/Application.vue
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/components/content/container/Application.vue
@@ -38,6 +38,20 @@
           @move-start="moveStart"
           @move-end="moveEnd" />
       </v-hover>
+      <div
+        v-show="hover && !editablePortlet"
+        class="full-width full-height position-absolute">
+        <v-expand-transition>
+          <v-card
+            v-if="hover"
+            :class="isDynamicSection && 'mb-5'"
+            :height="isDynamicSection && 'calc(100% - 20px)' || '100%'"
+            class="d-flex align-center justify-center full-width transition-fast-in-fast-out mask-color darken-2 v-card--reveal white--text">
+            <v-icon size="22" class="white--text me-2 mt-1">fab fa-readme</v-icon>
+            <span>{{ $t('layout.readonlyPortletContent') }}</span>
+          </v-card>
+        </v-expand-transition>
+      </div>
       <div v-if="displayNoContent" class="full-width text-no-wrap border-color-grey-lighten ms-1">
         <div class="layout-no-content absolute-vertical-center d-flex full-width ms-n1">
           <div class="light-black-background white--text px-2">
@@ -109,6 +123,12 @@ export default {
     },
     displayNoContent() {
       return this.isDynamicSection && !this.hasContent && this.$root.desktopDisplayMode;
+    },
+    portletInstance() {
+      return this.$root.portletInstances?.find?.(p => p.contentId === this.container?.contentId);
+    },
+    editablePortlet() {
+      return this.portletInstance?.editable || false;
     },
   },
   watch: {

--- a/layout-webapp/src/main/webapp/vue-app/portlet-editor/components/content/Cell.vue
+++ b/layout-webapp/src/main/webapp/vue-app/portlet-editor/components/content/Cell.vue
@@ -19,24 +19,44 @@
 
 -->
 <template>
-  <div
-    :style="cssStyle"
-    class="d-flex position-relative">
-    <v-card
-      v-if="isEmpty"
-      v-text="displayEmptyMessage && $t('portlets.emptyPortletInstanceContent') || ''"
-      class="d-flex align-center card-border-radius justify-center position-absolute full-width full-height"
-      flat />
-    <portlet-editor-application
-      ref="application"
-      @empty="isEmpty = $event"
-      @empty-message="displayEmptyMessage = true" />
-    <portlet-editor-cell-resize-button
-      ref="resizeButton"
-      v-if="$root.portletMode === 'view' && !isEmpty"
-      :moving="moving"
-      @move-start="moveStart" />
-  </div>
+  <v-hover v-model="hover" :disabled="!readOnly">
+    <div
+      :style="cssStyle"
+      class="d-flex position-relative">
+      <v-card
+        v-if="isEmpty"
+        v-text="displayEmptyMessage && $t('portlets.emptyPortletInstanceContent') || ''"
+        class="d-flex align-center card-border-radius justify-center position-absolute full-width full-height"
+        flat />
+      <div
+        v-else
+        v-show="hover && !hoverResizeButton"
+        class="full-width full-height position-absolute">
+        <v-expand-transition>
+          <v-card
+            v-if="hover && !hoverResizeButton"
+            class="d-flex align-center justify-center full-width transition-fast-in-fast-out mask-color darken-2 v-card--reveal white--text"
+            height="100%">
+            <v-icon size="22" class="white--text me-2 mt-1">fab fa-readme</v-icon>
+            <span>{{ $t('layout.readonlyPortletContent') }}</span>
+          </v-card>
+        </v-expand-transition>
+      </div>
+      <portlet-editor-application
+        ref="application"
+        @empty="isEmpty = $event"
+        @empty-message="displayEmptyMessage = true" />
+      <v-hover
+        v-if="$root.portletMode === 'view' && !isEmpty"
+        v-model="hoverResizeButton"
+        :disabled="!readOnly">
+        <portlet-editor-cell-resize-button
+          ref="resizeButton"
+          :moving="moving"
+          @move-start="moveStart" />
+      </v-hover>
+    </div>
+  </v-hover>
 </template>
 <script>
 export default {
@@ -49,6 +69,8 @@ export default {
     diffY: 0,
     updateDisplayInterval: 0,
     moving: false,
+    hoverResizeButton: false,
+    hover: false,
     isEmpty: null,
     displayEmptyMessage: false,
   }),
@@ -68,6 +90,9 @@ export default {
         width: this.width,
         height: this.height,
       };
+    },
+    readOnly() {
+      return this.$root.portletMode === 'view' && (!this.$root.editablePortlet || this.isEmpty);
     },
   },
   watch: {

--- a/layout-webapp/src/main/webapp/vue-app/portlet-editor/main.js
+++ b/layout-webapp/src/main/webapp/vue-app/portlet-editor/main.js
@@ -52,6 +52,11 @@ export function init() {
           portletInstanceEmpty: true,
           portletMode: 'view',
         },
+        computed: {
+          editablePortlet() {
+            return this.portletInstance?.editable || false;
+          },
+        },
         watch: {
           portletInstanceId: {
             immediate: true,


### PR DESCRIPTION
This change will allow to flag whether a portlet content changes affects only page instance currently in edition mode or it affects generic settings of platform by masking content on hover to not allow interact with portlet in page edit mode.