### PR TITLE
fix: Fix Missing Border Radius Switch Button - MEED-7083 - Meeds-io/meeds#2186

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/components/drawer/EditApplicationDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/components/drawer/EditApplicationDrawer.vue
@@ -153,12 +153,14 @@
             <v-checkbox v-model="boxShadow" />
           </v-list-item-action>
         </v-list-item>
-        <layout-editor-background-input
-          v-if="backgroundProperties"
-          ref="backgroundInput"
-          v-model="backgroundProperties"
-          immediate-save
-          class="mt-4" />
+        <div class="d-flex align-center mt-4">
+          <div class="subtitle-1 font-weight-bold me-auto">
+            {{ $t('layout.borderRadius') }}
+          </div>
+          <v-switch
+            v-model="enableBorderRadius"
+            class="ms-auto my-auto me-n2" />
+        </div>
         <div
           v-if="enableBorderRadius"
           :class="radiusChoice === 'same' && 'flex-row' || 'flex-column'"
@@ -216,6 +218,12 @@
               class="my-auto me-n3" />
           </v-list-item>
         </div>
+        <layout-editor-background-input
+          v-if="backgroundProperties"
+          ref="backgroundInput"
+          v-model="backgroundProperties"
+          immediate-save
+          class="mt-4" />
         <div class="d-flex align-center mt-4">
           <div class="subtitle-1 font-weight-bold me-auto mb-2">
             {{ $t('layout.advancedOptions') }}


### PR DESCRIPTION
Prior to this change, the Border Radius Button was missing which allow to customize the application border radius. This change will add it again.