### PR TITLE
fix: Fix SNV back url when editing Page Template - MEED-7084 - Meeds-io/meeds#2189

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/main.js
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/main.js
@@ -139,7 +139,9 @@ export function init() {
             }
           },
           nodeUri() {
-            if (this.nodeUri) {
+            if (window.opener) {
+              eXo.env.portal.webPageUrl = window.opener.location.pathname;
+            } else {
               eXo.env.portal.webPageUrl = `/portal${this.nodeUri}`;
             }
           },

--- a/layout-webapp/src/main/webapp/vue-app/page-template/components/list/PageTemplateItemMenu.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-template/components/list/PageTemplateItemMenu.vue
@@ -51,6 +51,7 @@
                   :href="editLayoutLink"
                   :disabled="pageTemplate.system"
                   target="_blank"
+                  rel="opener"
                   dense>
                   <v-icon
                     :class="pageTemplate.system && 'disabled--text'"


### PR DESCRIPTION
Prior to this change, when editing an SNV in a standalone Not Editor Page and then publishing, the displayed page is the Page Template Editor. This change will display the previous page before editing the page template.