### PR TITLE
feat: Display space name when editing navigation - MEED-7105 - Meeds-io/MIPs#137

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationDrawer.vue
@@ -34,7 +34,8 @@
           flat
           dense>
           <span
-            class="font-weight-bold">
+            :title="siteName"
+            class="font-weight-bold text-truncate">
             {{ siteName }}
           </span>
           <v-spacer v-if="!$refs.siteNavigationDrawer?.expand" />
@@ -118,7 +119,7 @@ export default {
   },
   methods: {
     open(event) {
-      this.siteName = event?.siteName || eXo.env.portal.siteKeyName;
+      this.siteName = event?.siteName || eXo.env.portal.spaceDisplayName;
       this.siteType = event?.siteType || 'PORTAL';
       this.siteId = event?.siteId || eXo.env.portal.siteId;
       this.includeGlobal = event?.includeGlobal || false;


### PR DESCRIPTION
Prior to this change the space technical name is display in the node drawer.
This PR allows to display the space name instead on the space technical name.