### PR TITLE
fix: Fix Application Layout CSS Class Computing - MEED-7321 - Meeds-io/meeds#2305

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/components/drawer/EditApplicationDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/components/drawer/EditApplicationDrawer.vue
@@ -265,6 +265,11 @@ export default {
     },
   },
   watch: {
+    drawer(value, oldVal) {
+      if (value && !oldVal && this.styleClasses) {
+        this.$layoutUtils.applyContainerStyle(this.container, this.styleClasses);
+      }
+    },
     styleClasses(value, oldVal) {
       if (value && oldVal) {
         this.$root.$emit('layout-section-history-add', this.sectionId);
@@ -300,7 +305,7 @@ export default {
       this.fixedHeight = !!this.height;
       this.applicationCategoryTitle = applicationCategoryTitle;
       this.applicationTitle = applicationTitle;
-      this.$layoutUtils.parseContainerStyle(this.container, this.styleClasses);
+      this.$layoutUtils.parseContainerStyle(this.container);
 
       this.backgroundProperties = {
         storageId: this.container.storageId,

--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/components/form/MarginInput.vue
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/components/form/MarginInput.vue
@@ -139,7 +139,6 @@ export default {
     marginLeft() {
       if (this.initialized) {
         this.$set(this.container, 'marginLeft', this.enabled ? this.marginLeft || 0 : null);
-        this.$set(this.container, 'marginLeft', this.marginLeft || null);
         this.$emit('refresh');
       }
     },

--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/js/LayoutUtils.js
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/js/LayoutUtils.js
@@ -267,10 +267,10 @@ export function applyContainerStyle(container, containerStyle) {
   } else {
     container.cssClass = container.cssClass.replace(new RegExp('(^| )(mt|mr|mb|ml|ms|me)-((md|lg|xl)-)?n?[0-9]{1,2}', 'g'), '').replace(/  +/g, ' ');
     if (containerStyle.marginTop === 0 || containerStyle.marginTop) {
-      container.cssClass += ` mt-${containerStyle.marginTop >= 0 ? '' : 'n'}${Math.abs(parseInt(Math.max(-20, Math.min(containerStyle.marginTop, 20)) / 4))}`;
-      container.cssClass += ` me-${containerStyle.marginRight >= 0 ? '' : 'n'}${Math.abs(parseInt(Math.max(-20, Math.min(containerStyle.marginRight, 20)) / 4))}`;
-      container.cssClass += ` mb-${containerStyle.marginBottom >= 0 ? '' : 'n'}${Math.abs(parseInt(Math.max(-20, Math.min(containerStyle.marginBottom, 20)) / 4))}`;
-      container.cssClass += ` ms-${containerStyle.marginLeft >= 0 ? '' : 'n'}${Math.abs(parseInt(Math.max(-20, Math.min(containerStyle.marginLeft, 20)) / 4))}`;
+      container.cssClass += ` mt-${containerStyle.marginTop >= 0 ? '' : 'n'}${Math.abs(parseInt(Math.max(-20, Math.min(containerStyle.marginTop || 0, 20)) / 4))}`;
+      container.cssClass += ` me-${containerStyle.marginRight >= 0 ? '' : 'n'}${Math.abs(parseInt(Math.max(-20, Math.min(containerStyle.marginRight || 0, 20)) / 4))}`;
+      container.cssClass += ` mb-${containerStyle.marginBottom >= 0 ? '' : 'n'}${Math.abs(parseInt(Math.max(-20, Math.min(containerStyle.marginBottom || 0, 20)) / 4))}`;
+      container.cssClass += ` ms-${containerStyle.marginLeft >= 0 ? '' : 'n'}${Math.abs(parseInt(Math.max(-20, Math.min(containerStyle.marginLeft || 0, 20)) / 4))}`;
     }
   }
 
@@ -728,10 +728,10 @@ export function parseContainerStyle(container) {
   if (container.template !== flexTemplate && container.template !== gridTemplate) {
     const marginMatches = container?.cssClass?.match?.(new RegExp('(^| )(mt|mr|mb|ml|ms|me)-((md|lg|xl)-)?n?[0-9]{1,2}', 'g')) || [];
     if (marginMatches?.length) {
-      container.marginTop = parseInt(marginMatches.find(c => c.indexOf('mt-') >= 0)?.replace?.('mt-n', '-')?.replace?.('mt-', '') || 0) * 4;
-      container.marginRight = parseInt(marginMatches.find(c => c.indexOf('me-') >= 0)?.replace?.('me-n', '-')?.replace?.('me-', '') || 0) * 4;
-      container.marginBottom = parseInt(marginMatches.find(c => c.indexOf('mb-') >= 0)?.replace?.('mb-n', '-')?.replace?.('mb-', '') || 0) * 4;
-      container.marginLeft = parseInt(marginMatches.find(c => c.indexOf('ms-') >= 0)?.replace?.('ms-n', '-')?.replace?.('ms-', '') || 0) * 4;
+      container.marginTop = parseInt(marginMatches.find(c => c.search(/mt-n?\d+/) >= 0)?.replace?.('mt-n', '-')?.replace?.('mt-', '') || 0) * 4;
+      container.marginRight = parseInt(marginMatches.find(c => c.search(/me-n?\d+/) >= 0)?.replace?.('me-n', '-')?.replace?.('me-', '') || 0) * 4;
+      container.marginBottom = parseInt(marginMatches.find(c => c.search(/mb-n?\d+/) >= 0)?.replace?.('mb-n', '-')?.replace?.('mb-', '') || 0) * 4;
+      container.marginLeft = parseInt(marginMatches.find(c => c.search(/ms-n?\d+/) >= 0)?.replace?.('ms-n', '-')?.replace?.('ms-', '') || 0) * 4;
     } else {
       container.marginTop = null;
       container.marginRight = null;


### PR DESCRIPTION
Prior to this change, the CSS Classes were duplicated in Application CSS Computed Class when there is already margin classes introduced in the custom attribute cssClass. This change ensures to not introduce twice the same class. Besides this change will apply 'mt-0' instead of 'mt-n0' class when margin is 20 to ensure to apply the right class even if not useful for now since the 'mt-0' applies a 0 margin.