### PR TITLE
feat: Fix site name in navigation drawer - MEED-7105 - Meeds-io/MIPs#137

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout-components/components/site-navigation/SiteNavigationDrawer.vue
@@ -119,7 +119,7 @@ export default {
   },
   methods: {
     open(event) {
-      this.siteName = event?.siteName || eXo.env.portal.spaceDisplayName;
+      this.siteName = event?.siteName || eXo.env.portal.spaceDisplayName || eXo.env.portal.siteKeyName;
       this.siteType = event?.siteType || 'PORTAL';
       this.siteId = event?.siteId || eXo.env.portal.siteId;
       this.includeGlobal = event?.includeGlobal || false;


### PR DESCRIPTION
Before this fix, the site name in the navigation drawer was displayed only for space sites. 
This PR allows to display the site name for all site types.
