### PR TITLE
feat: Description of templates are lost when editing - MEED-7344 - Meeds-io/MIPs#137

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -144,6 +144,7 @@ export default {
     async open(pageTemplate, duplicate, generateIllustration) {
       this.templateId = pageTemplate.id || this.$root.pageTemplate?.id || null;
       this.pageLayoutContent = pageTemplate.content;
+      this.description = pageTemplate?.description || '';
       this.duplicate = duplicate;
       if (generateIllustration) {
         const parentElement = document.querySelector('.layout-sections-parent .layout-page-body').parentElement;


### PR DESCRIPTION
Prior to this change when editing a template property, the template description is lost.
This PR addresses the issue by ensuring that the template description is preserved during property edits.