### PR TITLE
fix: Fix displaying inaccessible application - MEED-7411 - Meeds-io/MIPs#156

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common/js/ApplicationUtils.js
+++ b/layout-webapp/src/main/webapp/vue-app/common/js/ApplicationUtils.js
@@ -201,6 +201,10 @@ export function handleApplicationContent(applicationContent, applicationElement)
   const newHtmlDocument = document.createElement('div');
   newHtmlDocument.innerHTML = newBodyContent;
   const portletContent = newHtmlDocument.querySelector('.UIWorkingWorkspace .PORTLET-FRAGMENT');
+  if (!portletContent) {
+    applicationElement.classList.add('hidden');
+    return;
+  }
   const oldPortletContent = applicationElement.querySelector('.PORTLET-FRAGMENT');
   if (oldPortletContent) {
     oldPortletContent.remove();


### PR DESCRIPTION
Prior to this change, when adding a not accessible application inside a page using a dynamic container (with access permissions that the user is not member of), then a 'null' string is displayed instead of displaying an empty content. This change, ensures to not display the application at all and even hide the parent element to not have an additional padding.