### PR TITLE
feat: Display Space Category on two lines - MEED-7464 - Meeds-io/meeds#2374

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/components/content/common/ApplicationCategoryCard.vue
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/components/content/common/ApplicationCategoryCard.vue
@@ -32,7 +32,7 @@
       <v-icon class="mt-auto mb-2">{{ categoryIcon }}</v-icon>
       <div
         v-sanitized-html="categoryLabel"
-        class="text-truncate full-width mb-auto subtitle-2 mt-2 px-1"></div>
+        class="text-truncate-2 full-width mb-auto mt-2 px-1"></div>
     </v-card>
   </v-hover>
 </template>


### PR DESCRIPTION
This change will update Font-Size of Category Name to use the default one (16px for text-body) and will allow to display the name on two lines in layout editor.