### PR TITLE
feat: Allow to retrieve I18N keys for Sites Name and Description in UI - MEED-3342 - Meeds-io/meeds#1629

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/rest/SiteLayoutRest.java
+++ b/layout-service/src/main/java/io/meeds/layout/rest/SiteLayoutRest.java
@@ -45,6 +45,7 @@ import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.social.rest.entity.SiteEntity;
 
+import io.meeds.layout.model.NodeLabel;
 import io.meeds.layout.model.PermissionUpdateModel;
 import io.meeds.layout.model.SiteCreateModel;
 import io.meeds.layout.model.SiteUpdateModel;
@@ -231,6 +232,48 @@ public class SiteLayoutRest {
                            .eTag(String.valueOf(Objects.hash(siteEntity, request.getLocale())))
                            .body(siteEntity);
     } catch (ObjectAlreadyExistsException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    } catch (IllegalAccessException e) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage());
+    }
+  }
+
+  @GetMapping("{siteId}/labels")
+  @Operation(summary = "Retrieve site I18N labels", method = "GET", description = "This retrieves site labels")
+  @ApiResponses(value = {
+                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+                          @ApiResponse(responseCode = "403", description = "Forbidden"),
+                          @ApiResponse(responseCode = "404", description = "Not found"),
+  })
+  public NodeLabel getSiteLabels(
+                                 HttpServletRequest request,
+                                 @Parameter(description = "Site id", required = true)
+                                 @PathVariable("siteId")
+                                 Long siteId) {
+    try {
+      return siteLayoutService.getSiteLabels(siteId, request.getRemoteUser());
+    } catch (ObjectNotFoundException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    } catch (IllegalAccessException e) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage());
+    }
+  }
+
+  @GetMapping("{siteId}/descriptions")
+  @Operation(summary = "Retrieve site I18N descriptions", method = "GET", description = "This retrieves site descriptions")
+  @ApiResponses(value = {
+                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+                          @ApiResponse(responseCode = "403", description = "Forbidden"),
+                          @ApiResponse(responseCode = "404", description = "Not found"),
+  })
+  public NodeLabel getSiteDescriptions(
+                                       HttpServletRequest request,
+                                       @Parameter(description = "Site id", required = true)
+                                       @PathVariable("siteId")
+                                       Long siteId) {
+    try {
+      return siteLayoutService.getSiteDescriptions(siteId, request.getRemoteUser());
+    } catch (ObjectNotFoundException e) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
     } catch (IllegalAccessException e) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage());

--- a/layout-service/src/test/java/io/meeds/layout/rest/SiteLayoutRestTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/rest/SiteLayoutRestTest.java
@@ -18,57 +18,59 @@
  */
 package io.meeds.layout.rest;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import io.meeds.layout.service.PortletService;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+
+import io.meeds.layout.model.NodeLabel;
+import io.meeds.layout.service.SiteLayoutService;
 import io.meeds.spring.web.security.PortalAuthenticationManager;
 import io.meeds.spring.web.security.WebSecurityConfiguration;
 
 import jakarta.servlet.Filter;
 
-@SpringBootTest(classes = { PortletRest.class, PortalAuthenticationManager.class, })
+@SpringBootTest(classes = { SiteLayoutRest.class, PortalAuthenticationManager.class, })
 @ContextConfiguration(classes = { WebSecurityConfiguration.class })
 @AutoConfigureWebMvc
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
-public class PortletRestTest {
+public class SiteLayoutRestTest {
 
-  private static final String   REST_PATH     = "/portlets";   // NOSONAR
-
-  private static final String   SIMPLE_USER   = "simple";
-
-  private static final String   TEST_PASSWORD = "testPassword";
+  private static final String   REST_PATH = "/sites"; // NOSONAR
 
   @MockBean
-  private PortletService        portletService;
+  private SiteLayoutService     siteLayoutService;
 
   @Autowired
   private SecurityFilterChain   filterChain;
 
   @Autowired
   private WebApplicationContext context;
+
+  @Mock
+  private NodeLabel             nodeLabel;
 
   private MockMvc               mockMvc;
 
@@ -80,46 +82,47 @@ public class PortletRestTest {
   }
 
   @Test
-  void getPortletsAnonymously() throws Exception {
-    ResultActions response = mockMvc.perform(get(REST_PATH));
+  void getSiteLabels() throws Exception {
+    doThrow(ObjectNotFoundException.class).when(siteLayoutService)
+                                          .getSiteLabels(2l, null);
+
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/2/labels"));
+    response.andExpect(status().isNotFound());
+
+    doThrow(IllegalAccessException.class).when(siteLayoutService)
+                                         .getSiteLabels(3l, null);
+    response = mockMvc.perform(get(REST_PATH + "/3/labels"));
     response.andExpect(status().isForbidden());
-    verifyNoInteractions(portletService);
+
+    doReturn(nodeLabel).when(siteLayoutService)
+                       .getSiteLabels(4l, null);
+    when(nodeLabel.getDefaultLanguage()).thenReturn("en");
+
+    response = mockMvc.perform(get(REST_PATH + "/4/labels"));
+    response.andExpect(status().isOk())
+            .andExpect(jsonPath("$.defaultLanguage").value("en"));
   }
 
   @Test
-  void getPortletsWithContributor() throws Exception {
-    ResultActions response = mockMvc.perform(get(REST_PATH).with(testContributorUser()));
-    response.andExpect(status().isOk());
-    verify(portletService).getPortlets();
-  }
+  void getSiteDescriptions() throws Exception {
+    doThrow(ObjectNotFoundException.class).when(siteLayoutService)
+                                          .getSiteDescriptions(2l, null);
 
-  @Test
-  void getPortletsWithAdmin() throws Exception {
-    ResultActions response = mockMvc.perform(get(REST_PATH).with(testAdminUser()));
-    response.andExpect(status().isOk());
-    verify(portletService).getPortlets();
-  }
+    ResultActions response = mockMvc.perform(get(REST_PATH + "/2/descriptions"));
+    response.andExpect(status().isNotFound());
 
-  @Test
-  void getPortletsWithSimple() throws Exception {
-    ResultActions response = mockMvc.perform(get(REST_PATH).with(testSimpleUser()));
+    doThrow(IllegalAccessException.class).when(siteLayoutService)
+                                         .getSiteDescriptions(3l, null);
+    response = mockMvc.perform(get(REST_PATH + "/3/descriptions"));
     response.andExpect(status().isForbidden());
-    verifyNoInteractions(portletService);
-  }
 
-  private RequestPostProcessor testContributorUser() {
-    return user(SIMPLE_USER).password(TEST_PASSWORD)
-                            .authorities(new SimpleGrantedAuthority("web-contributors"));
-  }
+    doReturn(nodeLabel).when(siteLayoutService)
+                       .getSiteDescriptions(4l, null);
+    when(nodeLabel.getDefaultLanguage()).thenReturn("en");
 
-  private RequestPostProcessor testAdminUser() {
-    return user(SIMPLE_USER).password(TEST_PASSWORD)
-                            .authorities(new SimpleGrantedAuthority("administrators"));
-  }
-
-  private RequestPostProcessor testSimpleUser() {
-    return user(SIMPLE_USER).password(TEST_PASSWORD)
-                            .authorities(new SimpleGrantedAuthority("users"));
+    response = mockMvc.perform(get(REST_PATH + "/4/descriptions"));
+    response.andExpect(status().isOk())
+            .andExpect(jsonPath("$.defaultLanguage").value("en"));
   }
 
 }

--- a/layout-webapp/src/main/webapp/vue-app/common/js/SiteLayoutService.js
+++ b/layout-webapp/src/main/webapp/vue-app/common/js/SiteLayoutService.js
@@ -83,6 +83,32 @@ export function getSite(siteType, siteName, lang) {
   });
 }
 
+export function getSiteLabels(siteId) {
+  return fetch(`/layout/rest/sites/${siteId}/labels`, {
+    credentials: 'include',
+    method: 'GET'
+  }).then(resp => {
+    if (resp?.ok) {
+      return resp.json();
+    } else {
+      throw new Error('Error when retrieving site labels');
+    }
+  });
+}
+
+export function getSiteDescriptions(siteId) {
+  return fetch(`/layout/rest/sites/${siteId}/descriptions`, {
+    credentials: 'include',
+    method: 'GET'
+  }).then(resp => {
+    if (resp?.ok) {
+      return resp.json();
+    } else {
+      throw new Error('Error when retrieving site descriptions');
+    }
+  });
+}
+
 export function updateSite(siteName, siteType, siteLabel, siteDescription, displayed, displayOrder, bannerUploadId, bannerRemoved) {
   const updateModel = {
     siteType,


### PR DESCRIPTION
After the enhanced behavior made on Meeds-io/gatein-portal#969 and Meeds-io/social#4028, this change will allow to provide sites translated names and descriptions coming from crowdin synchronized properties files.