### PR TITLE
feat: Allow Layout Edit Button To administrators only - MEED-7509 - Meeds-io/MIPs#147

### DIFF
--- a/layout-webapp/src/main/webapp/WEB-INF/conf/layout/dynamic-container-configuration.xml
+++ b/layout-webapp/src/main/webapp/WEB-INF/conf/layout/dynamic-container-configuration.xml
@@ -19,7 +19,11 @@
 	Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 -->
-<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+<configuration
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
   <external-component-plugins>
     <target-component>org.exoplatform.commons.addons.AddOnService</target-component>
     <component-plugin>
@@ -46,7 +50,7 @@
             <field name="permissions">
               <collection type="java.util.ArrayList">
                 <value>
-                  <string>*:/platform/users</string>
+                  <string>*:/platform/administrators</string>
                 </value>
               </collection>
             </field>


### PR DESCRIPTION
This change will just hide the button of Layout edition from Top Bar, so that only super administrators will be able to access it. This will avoid space manager to access this feature by UI until a rework is made on permissions model to let Platform administrators choose who will be able to access this feature and button. Besides, improving the permissions model means that the Portal MOP permission (portal layer) has to be delegated to SpaceService (social) layer which will be improved in a dedicated MIP (Space Templates).