### PR TITLE
feat: Update calls to UserACL to avoid implicit usage of Conversation State in Service Layer - MEED-7555 - Meeds-io/MIPs#151

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/plugin/attachment/PortletInstanceAttachmentPlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/attachment/PortletInstanceAttachmentPlugin.java
@@ -77,7 +77,7 @@ public class PortletInstanceAttachmentPlugin extends AttachmentPlugin {
     List<String> permissions = portletInstance.getPermissions();
     return CollectionUtils.isEmpty(permissions)
            || (userIdentity != null
-               && permissions.stream().anyMatch(p -> layoutAclService.isMemberOf(userIdentity.getUserId(), p)));
+               && permissions.stream().anyMatch(p -> layoutAclService.hasPermission(userIdentity.getUserId(), p)));
   }
 
   @Override

--- a/layout-service/src/main/java/io/meeds/layout/plugin/translation/PortletInstanceCategoryTranslationPlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/translation/PortletInstanceCategoryTranslationPlugin.java
@@ -76,7 +76,7 @@ public class PortletInstanceCategoryTranslationPlugin extends TranslationPlugin 
     }
     List<String> permissions = category.getPermissions();
     return CollectionUtils.isEmpty(permissions)
-           || permissions.stream().anyMatch(p -> layoutAclService.isMemberOf(username, p));
+           || permissions.stream().anyMatch(p -> layoutAclService.hasPermission(username, p));
   }
 
   @Override

--- a/layout-service/src/main/java/io/meeds/layout/plugin/translation/PortletInstanceTranslationPlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/translation/PortletInstanceTranslationPlugin.java
@@ -78,7 +78,7 @@ public class PortletInstanceTranslationPlugin extends TranslationPlugin {
     }
     List<String> permissions = portletInstance.getPermissions();
     return CollectionUtils.isEmpty(permissions)
-           || permissions.stream().anyMatch(p -> layoutAclService.isMemberOf(username, p));
+           || permissions.stream().anyMatch(p -> layoutAclService.hasPermission(username, p));
   }
 
   @Override

--- a/layout-service/src/main/java/io/meeds/layout/rest/model/LayoutModel.java
+++ b/layout-service/src/main/java/io/meeds/layout/rest/model/LayoutModel.java
@@ -165,10 +165,6 @@ public class LayoutModel {
   // Specific to container
   private String                          profiles;
 
-  private String[]                        moveAppsPermissions;
-
-  private String[]                        moveContainersPermissions;
-
   private List<PortletInstancePreference> preferences;
 
   private List<LayoutModel>               children;
@@ -260,8 +256,6 @@ public class LayoutModel {
       this.cssClass = container.getCssClass();
       this.profiles = container.getProfiles();
       this.accessPermissions = container.getAccessPermissions();
-      this.moveAppsPermissions = container.getMoveAppsPermissions();
-      this.moveContainersPermissions = container.getMoveContainersPermissions();
       this.children = container.getChildren().stream().map(LayoutModel::new).toList();
 
       ApplicationBackgroundStyle appCssStyle = container.getAppBackgroundStyle();
@@ -344,8 +338,6 @@ public class LayoutModel {
       container.setCssClass(layoutModel.getCssClass());
       container.setProfiles(layoutModel.getProfiles());
       container.setAccessPermissions(layoutModel.getAccessPermissions());
-      container.setMoveAppsPermissions(layoutModel.getMoveAppsPermissions());
-      container.setMoveContainersPermissions(layoutModel.getMoveContainersPermissions());
       container.setCssStyle(cssStyle);
       container.setAppBackgroundStyle(mapToAppStyle(layoutModel));
       if (layoutModel.getChildren() != null) {

--- a/layout-service/src/main/java/io/meeds/layout/service/PageLayoutService.java
+++ b/layout-service/src/main/java/io/meeds/layout/service/PageLayoutService.java
@@ -296,8 +296,6 @@ public class PageLayoutService {
                                        pageState.getFactoryId(),
                                        pageState.getAccessPermissions(),
                                        pageState.getEditPermission(),
-                                       pageState.getMoveAppsPermissions(),
-                                       pageState.getMoveContainersPermissions(),
                                        pageState.getType(),
                                        link));
     layoutService.save(pageContext);
@@ -323,8 +321,6 @@ public class PageLayoutService {
                                        pageState.getFactoryId(),
                                        accessPermissionsList,
                                        editPermission,
-                                       pageState.getMoveAppsPermissions(),
-                                       pageState.getMoveContainersPermissions(),
                                        pageState.getType(),
                                        pageState.getLink()));
     layoutService.save(pageContext);

--- a/layout-service/src/main/java/io/meeds/layout/service/PortletInstanceService.java
+++ b/layout-service/src/main/java/io/meeds/layout/service/PortletInstanceService.java
@@ -329,7 +329,7 @@ public class PortletInstanceService {
     }
     if (!layoutAclService.isAdministrator(username)
         && Arrays.stream(application.getAccessPermissions())
-                 .noneMatch(permission -> layoutAclService.isMemberOf(username, permission))) {
+                 .noneMatch(permission -> layoutAclService.hasPermission(username, permission))) {
       throw new IllegalAccessException(String.format("Application with id %s access denied", applicationId));
     }
     return getApplicationPreferences(application);
@@ -453,13 +453,13 @@ public class PortletInstanceService {
     List<String> permissions = portletInstance.getPermissions();
     return CollectionUtils.isEmpty(permissions)
            || permissions.equals(EVERYONE_PERMISSIONS_LIST)
-           || (StringUtils.isNotBlank(username) && permissions.stream().anyMatch(p -> layoutAclService.isMemberOf(username, p)));
+           || (StringUtils.isNotBlank(username) && permissions.stream().anyMatch(p -> layoutAclService.hasPermission(username, p)));
   }
 
   private boolean hasPermission(PortletInstanceCategory category, String username) {
     List<String> permissions = category.getPermissions();
     return CollectionUtils.isEmpty(permissions)
            || permissions.equals(EVERYONE_PERMISSIONS_LIST)
-           || (StringUtils.isNotBlank(username) && permissions.stream().anyMatch(p -> layoutAclService.isMemberOf(username, p)));
+           || (StringUtils.isNotBlank(username) && permissions.stream().anyMatch(p -> layoutAclService.hasPermission(username, p)));
   }
 }

--- a/layout-service/src/main/java/io/meeds/layout/storage/PortletInstanceLayoutStorage.java
+++ b/layout-service/src/main/java/io/meeds/layout/storage/PortletInstanceLayoutStorage.java
@@ -207,9 +207,7 @@ public class PortletInstanceLayoutStorage {
                                           false,
                                           null,
                                           Arrays.asList(UserACL.EVERYONE),
-                                          page.getEditPermission(),
-                                          Arrays.asList(UserACL.EVERYONE),
-                                          Arrays.asList(UserACL.EVERYONE));
+                                          page.getEditPermission());
       layoutService.save(new PageContext(PORTLET_EDITOR_SYSTEM_PAGE_KEY, pageState), page);
       page = layoutService.getPage(PORTLET_EDITOR_SYSTEM_PAGE_KEY);
     }

--- a/layout-service/src/test/java/io/meeds/layout/plugin/attachment/PortletInstanceAttachmentPluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/attachment/PortletInstanceAttachmentPluginTest.java
@@ -98,7 +98,7 @@ public class PortletInstanceAttachmentPluginTest {
     when(portletInstance.getPermissions()).thenReturn(Collections.singletonList(permissionExpression));
     assertFalse(attachmentPlugin.hasAccessPermission(userIdentity, "1"));
 
-    when(layoutAclService.isMemberOf(username, permissionExpression)).thenReturn(true);
+    when(layoutAclService.hasPermission(username, permissionExpression)).thenReturn(true);
     assertTrue(attachmentPlugin.hasAccessPermission(userIdentity, "1"));
   }
 

--- a/layout-service/src/test/java/io/meeds/layout/plugin/translation/PortletInstanceCategoryTranslationPluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/translation/PortletInstanceCategoryTranslationPluginTest.java
@@ -91,7 +91,7 @@ public class PortletInstanceCategoryTranslationPluginTest {
     when(portletInstanceCategory.getPermissions()).thenReturn(Collections.singletonList(permissionExpression));
     assertFalse(translationPlugin.hasAccessPermission(1, username));
 
-    when(layoutAclService.isMemberOf(username, permissionExpression)).thenReturn(true);
+    when(layoutAclService.hasPermission(username, permissionExpression)).thenReturn(true);
     assertTrue(translationPlugin.hasAccessPermission(1, username));
   }
 

--- a/layout-service/src/test/java/io/meeds/layout/plugin/translation/PortletInstanceTranslationPluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/translation/PortletInstanceTranslationPluginTest.java
@@ -91,7 +91,7 @@ public class PortletInstanceTranslationPluginTest {
     when(portletInstance.getPermissions()).thenReturn(Collections.singletonList(permissionExpression));
     assertFalse(translationPlugin.hasAccessPermission(1, username));
 
-    when(layoutAclService.isMemberOf(username, permissionExpression)).thenReturn(true);
+    when(layoutAclService.hasPermission(username, permissionExpression)).thenReturn(true);
     assertTrue(translationPlugin.hasAccessPermission(1, username));
   }
 

--- a/layout-webapp/src/main/webapp/WEB-INF/jsp/siteNavigation.jsp
+++ b/layout-webapp/src/main/webapp/WEB-INF/jsp/siteNavigation.jsp
@@ -1,13 +1,9 @@
 <%@page import="io.meeds.layout.service.LayoutAclService"%>
 <%@page import="org.exoplatform.container.ExoContainerContext"%>
-<%@page import="org.exoplatform.portal.webui.util.NavigationUtils"%>
 <%@page import="org.exoplatform.portal.webui.util.Util"%>
 <%@page import="org.exoplatform.portal.mop.SiteKey"%>
-<%@page import="org.exoplatform.portal.mop.user.UserNavigation"%>
 <%
   SiteKey siteKey = Util.getUIPortal().getSiteKey();
-  UserNavigation userNavigation = NavigationUtils.getUserNavigation(Util.getPortalRequestContext().getUserPortalConfig().getUserPortal(),
-                                                                    siteKey);
   LayoutAclService aclService = ExoContainerContext.getService(LayoutAclService.class);
   boolean isAdministrator = aclService.isAdministrator(request.getRemoteUser());
   boolean canManageSiteNavigation = aclService.canEditNavigation(siteKey, request.getRemoteUser());

--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/js/LayoutUtils.js
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/js/LayoutUtils.js
@@ -105,10 +105,6 @@ export const containerModel = {
   // Generally kept to be accessible to everyone to make
   // the parent page access permissions applied globally 
   accessPermissions: ['Everyone'],
-  // Deprecated, not used for containers
-  moveAppsPermissions: ['Everyone'],
-  // Deprecated, not used for containers
-  moveContainersPermissions: ['Everyone'],
   // List of children which can be of type:
   // 1. Container
   //   or


### PR DESCRIPTION
This change will update UserACL usage to not implicitly use the current conversation state of authenticated user.