### PR TITLE
fix: Fix Portlet preloading URL and Crossorigin - Meeds-io/meeds#2483

### DIFF
--- a/layout-webapp/src/main/webapp/groovy/portal/webui/container/UIPageLayout.gtmpl
+++ b/layout-webapp/src/main/webapp/groovy/portal/webui/container/UIPageLayout.gtmpl
@@ -18,7 +18,7 @@
       def portletId = portlets.get(i).getId();
       if (portletId != null) {
         %>
-        <link rel="prefetch" as="fetch" type="text/html" href="<%=rcontext.getRequest().getRequestURI()%>?maximizedPortletId<%=portletId%>&showMaxWindow=true&hideSharedLayout=true&maximizedPortletMode=VIEW" crossorigin><%
+        <link rel="preload" as="fetch" href="<%=rcontext.getRequest().getRequestURI()%>?maximizedPortletId=<%=portletId%>&showMaxWindow=true&hideSharedLayout=true&maximizedPortletMode=VIEW" crossorigin="use-credentials"><%
       }
     }
   }


### PR DESCRIPTION
Prior to this change, the URL to preload when displaying the page is different from the loaded fetch call using JS services of the page layout. In addition, the crossorigin attribute has to be the same as the fetch call 'credentials' attribute which is with value 'include'.

Resolves Meeds-io/meeds#2483