### PR TITLE
feat: Review Portlet Instances Default Permissions - MEED-7668 - Meeds-io/meeds#2528

### DIFF
--- a/layout-service/src/main/resources/portlet-instances.json
+++ b/layout-service/src/main/resources/portlet-instances.json
@@ -146,7 +146,8 @@
         
       ],
       "permissions":[
-        "*:/platform/users"
+        "*:/platform/administrators",
+        "*:/platform/web-contributors"
       ],
       "system":true
     },


### PR DESCRIPTION
This change will hide `PeopleOverview` portlet instance for Space Managers when editing their layout to be visible for administrators and content managers only.