### PR TITLE
fix: Preserve Data when duplicating Image or Link Portlet - MEED-7687 - Meeds-io/MIPs#165

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/plugin/renderer/ImagePortletInstancePreferencePlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/renderer/ImagePortletInstancePreferencePlugin.java
@@ -68,6 +68,11 @@ public class ImagePortletInstancePreferencePlugin implements PortletInstancePref
   @SneakyThrows
   public List<PortletInstancePreference> generatePreferences(Application application,
                                                              Portlet preferences) {
+    if (preferences != null && preferences.getPreference(DATA_INIT_PREFERENCE_NAME) != null) {
+      return Collections.singletonList(new PortletInstancePreference(DATA_INIT_PREFERENCE_NAME,
+                                                                     preferences.getPreference(DATA_INIT_PREFERENCE_NAME)
+                                                                                .getValue()));
+    }
     String settingName = getCmsSettingName(preferences);
     if (StringUtils.isBlank(settingName)) {
       return Collections.emptyList();

--- a/layout-service/src/main/java/io/meeds/layout/plugin/renderer/LinkPortletInstancePreferencePlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/renderer/LinkPortletInstancePreferencePlugin.java
@@ -56,6 +56,11 @@ public class LinkPortletInstancePreferencePlugin implements PortletInstancePrefe
   @SneakyThrows
   public List<PortletInstancePreference> generatePreferences(Application application,
                                                              Portlet preferences) {
+    if (preferences != null && preferences.getPreference(DATA_INIT_PREFERENCE_NAME) != null) {
+      return Collections.singletonList(new PortletInstancePreference(DATA_INIT_PREFERENCE_NAME,
+                                                                     preferences.getPreference(DATA_INIT_PREFERENCE_NAME)
+                                                                                .getValue()));
+    }
     String settingName = getCmsSettingName(preferences);
     if (StringUtils.isBlank(settingName)) {
       return Collections.emptyList();

--- a/layout-service/src/main/java/io/meeds/layout/service/NavigationLayoutService.java
+++ b/layout-service/src/main/java/io/meeds/layout/service/NavigationLayoutService.java
@@ -37,7 +37,6 @@ import org.springframework.stereotype.Service;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.ExpressionUtil;
 import org.exoplatform.portal.application.PortalRequestHandler;
-import org.exoplatform.portal.application.PortalTemplateRequestHandler;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.SiteType;
@@ -62,6 +61,7 @@ import io.meeds.common.ContainerTransactional;
 import io.meeds.layout.model.NavigationCreateModel;
 import io.meeds.layout.model.NavigationUpdateModel;
 import io.meeds.layout.model.NodeLabel;
+import io.meeds.portal.web.handler.PortalTemplateRequestHandler;
 
 @Service
 public class NavigationLayoutService {


### PR DESCRIPTION
Prior to this change, when the Image or Link Portlet doesn't have been initialized/displayed yet in a page, like the default Space Templates, the 'data.init' preference isn't used to initialize the portlet yet and thus when duplicating the page template, the 'data.init' has to be reused instead of generated only when the CMS portlet is initialized.