### PR TITLE
fix: Avoid displaying Empty containers - MEED-7939 - Meeds-io/meeds#2670

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/CellContainer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/CellContainer.vue
@@ -20,7 +20,6 @@
 -->
 <template>
   <page-layout-container-base
-    v-if="hasChildren"
     :container="container"
     :parent-id="parentId" />
 </template>
@@ -34,11 +33,6 @@ export default {
     parentId: {
       type: String,
       default: null,
-    },
-  },
-  computed: {
-    hasChildren() {
-      return this.container?.children?.length;
     },
   },
 };

--- a/layout-webapp/src/main/webapp/vue-app/page-layout/extensions.js
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/extensions.js
@@ -25,6 +25,13 @@ extensionRegistry.registerExtension('page-layout', 'container', {
 });
 
 extensionRegistry.registerExtension('page-layout', 'container', {
+  rank: 400,
+  type: 'cell',
+  isValid: container => container.template === 'CellContainer',
+  containerType: 'page-layout-cell-container',
+});
+
+extensionRegistry.registerExtension('page-layout', 'container', {
   rank: 200,
   type: 'section',
   isValid: container => container.template === 'FlexContainer',

--- a/layout-webapp/src/main/webapp/vue-app/page-layout/initComponents.js
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/initComponents.js
@@ -25,6 +25,7 @@ import ContainerBase from './components/base/ContainerBase.vue';
 import PageContainer from './components/container/PageContainer.vue';
 import DynamicSection from './components/container/DynamicSection.vue';
 import FixedSection from './components/container/FixedSection.vue';
+import CellContainer from './components/container/CellContainer.vue';
 import Container from './components/container/Container.vue';
 import Application from './components/container/Application.vue';
 
@@ -37,6 +38,7 @@ const components = {
   'page-layout-page-container': PageContainer,
   'page-layout-dynamic-section': DynamicSection,
   'page-layout-fixed-section': FixedSection,
+  'page-layout-cell-container': CellContainer,
   'page-layout-container': Container,
   'page-layout-application': Application,
 };


### PR DESCRIPTION
Prior to this change, when a container has an empty content, it displays an empty div. This may lead to not have the `Sticky` behavior to work. Thus, this change will simply avoid displaying containers having empty contents.

Resolves https://github.com/Meeds-io/meeds/issues/2670