### PR TITLE
feat: Enhance Page Template Listing Performances - MEED-8266 - Meeds-io/MIPs#175

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/plugin/upgrade/SpaceBannerHomePageUpgradePlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/upgrade/SpaceBannerHomePageUpgradePlugin.java
@@ -98,6 +98,7 @@ public class SpaceBannerHomePageUpgradePlugin extends LayoutApplicationReference
     }
   }
 
+  @SuppressWarnings("unchecked")
   private List<Long> getSpaceHomePages() {
     RequestLifeCycle.begin(this.entityManagerService);
     EntityManager entityManager = this.entityManagerService.getEntityManager();

--- a/layout-service/src/main/java/io/meeds/layout/rest/PageTemplateRest.java
+++ b/layout-service/src/main/java/io/meeds/layout/rest/PageTemplateRest.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -57,31 +58,36 @@ public class PageTemplateRest {
   @Secured("users")
   @Operation(summary = "Retrieve page templates", method = "GET", description = "This retrieves page templates")
   @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"), })
-  public List<PageTemplate> getPageTemplates(HttpServletRequest request) {
-    return pageTemplateService.getPageTemplates(request.getLocale(), true);
+  public List<PageTemplate> getPageTemplates(HttpServletRequest request,
+                                             @Parameter(description = "Whether to retrieve page template content or not", required = false)
+                                             @RequestParam(name = "expandContent", required = false, defaultValue = "false")
+                                             boolean expandContent) {
+    return pageTemplateService.getPageTemplates(request.getLocale(), true, expandContent);
   }
 
   @GetMapping("{id}")
   @Secured("users")
-  @Operation(summary = "Retrieve a page template designated by its id", method = "GET",
-             description = "This will retrieve a page template designated by its id")
+  @Operation(summary = "Retrieve a page template designated by its id", method = "GET", description = "This will retrieve a page template designated by its id")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
   })
   public PageTemplate getPageTemplate(
                                       HttpServletRequest request,
                                       @Parameter(description = "Page template identifier")
                                       @PathVariable("id")
-                                      long id) {
-    return pageTemplateService.getPageTemplate(id, request.getLocale(), true);
+                                      long id,
+                                      @Parameter(description = "Whether to retrieve page template content or not", required = false)
+                                      @RequestParam(name = "expandContent", required = false, defaultValue = "false")
+                                      boolean expandContent) {
+    return pageTemplateService.getPageTemplate(id, request.getLocale(), true, expandContent);
   }
 
   @PostMapping
   @Secured("users")
   @Operation(summary = "Create a page template", method = "POST", description = "This creates a new page template")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-                          @ApiResponse(responseCode = "403", description = "Forbidden"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "403", description = "Forbidden"),
   })
   public PageTemplate createPageTemplate(
                                          HttpServletRequest request,
@@ -98,9 +104,9 @@ public class PageTemplateRest {
   @Secured("users")
   @Operation(summary = "Update a page template", method = "PUT", description = "This updates an existing page template")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-                          @ApiResponse(responseCode = "403", description = "Forbidden"),
-                          @ApiResponse(responseCode = "404", description = "Not found"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "403", description = "Forbidden"),
+    @ApiResponse(responseCode = "404", description = "Not found"),
   })
   public void updatePageTemplate(
                                  HttpServletRequest request,
@@ -123,9 +129,9 @@ public class PageTemplateRest {
   @Secured("users")
   @Operation(summary = "Deletes a page template", method = "DELETE", description = "This deletes an existing page template")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-                          @ApiResponse(responseCode = "403", description = "Forbidden"),
-                          @ApiResponse(responseCode = "404", description = "Not found"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "403", description = "Forbidden"),
+    @ApiResponse(responseCode = "404", description = "Not found"),
   })
   public void deletePageTemplate(
                                  HttpServletRequest request,

--- a/layout-service/src/main/java/io/meeds/layout/service/PageTemplateService.java
+++ b/layout-service/src/main/java/io/meeds/layout/service/PageTemplateService.java
@@ -68,17 +68,25 @@ public class PageTemplateService {
   }
 
   public List<PageTemplate> getPageTemplates(Locale locale, boolean expand) {
+    return getPageTemplates(locale, expand, true);
+  }
+
+  public List<PageTemplate> getPageTemplates(Locale locale, boolean expand, boolean retrieveContent) {
     List<PageTemplate> pageTemplates = pageTemplateStorage.getPageTemplates();
     if (expand) {
-      pageTemplates.forEach(pageTemplate -> computePageTemplateAttributes(locale, pageTemplate));
+      pageTemplates.forEach(pageTemplate -> computePageTemplateAttributes(locale, pageTemplate, retrieveContent));
     }
     return pageTemplates;
   }
 
   public PageTemplate getPageTemplate(long id, Locale locale, boolean expand) {
+    return getPageTemplate(id, locale, expand, false);
+  }
+
+  public PageTemplate getPageTemplate(long id, Locale locale, boolean expand, boolean retrieveContent) {
     PageTemplate pageTemplate = pageTemplateStorage.getPageTemplate(id);
     if (expand) {
-      computePageTemplateAttributes(locale, pageTemplate);
+      computePageTemplateAttributes(locale, pageTemplate, retrieveContent);
     }
     return pageTemplate;
   }
@@ -164,13 +172,16 @@ public class PageTemplateService {
     }
   }
 
-  private void computePageTemplateAttributes(Locale locale, PageTemplate pageTemplate) {
+  private void computePageTemplateAttributes(Locale locale, PageTemplate pageTemplate, boolean retrieveContent) {
     pageTemplate.setName(getLabel(pageTemplate.getId(), PageTemplateTranslationPlugin.TITLE_FIELD_NAME, locale));
     pageTemplate.setDescription(getLabel(pageTemplate.getId(), PageTemplateTranslationPlugin.DESCRIPTION_FIELD_NAME, locale));
     List<String> attachmentFileIds = attachmentService.getAttachmentFileIds(PageTemplateAttachmentPlugin.OBJECT_TYPE,
                                                                             String.valueOf(pageTemplate.getId()));
     if (CollectionUtils.isNotEmpty(attachmentFileIds)) {
       pageTemplate.setIllustrationId(Long.parseLong(attachmentFileIds.get(0)));
+    }
+    if (!retrieveContent) {
+      pageTemplate.setContent(null);
     }
   }
 

--- a/layout-service/src/test/java/io/meeds/layout/rest/PageTemplateRestTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/rest/PageTemplateRestTest.java
@@ -103,7 +103,7 @@ public class PageTemplateRestTest {
   void getPageTemplatesWithUser() throws Exception {
     ResultActions response = mockMvc.perform(get(REST_PATH).with(testSimpleUser()));
     response.andExpect(status().isOk());
-    verify(pageTemplateService).getPageTemplates(any(), anyBoolean());
+    verify(pageTemplateService).getPageTemplates(any(), anyBoolean(), anyBoolean());
   }
 
   @Test
@@ -117,7 +117,7 @@ public class PageTemplateRestTest {
   void getPageTemplateWithUser() throws Exception {
     ResultActions response = mockMvc.perform(get(REST_PATH + "/1").with(testSimpleUser()));
     response.andExpect(status().isOk());
-    verify(pageTemplateService).getPageTemplate(eq(1l), any(), eq(true));
+    verify(pageTemplateService).getPageTemplate(eq(1l), any(), eq(true), eq(false));
   }
 
   @Test

--- a/layout-service/src/test/java/io/meeds/layout/service/PageTemplateServiceTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/service/PageTemplateServiceTest.java
@@ -197,7 +197,7 @@ public class PageTemplateServiceTest {
     when(translationService.getTranslationField(PageTemplateTranslationPlugin.OBJECT_TYPE,
                                                 template.getId(),
                                                 PageTemplateTranslationPlugin.TITLE_FIELD_NAME)).thenThrow(ObjectNotFoundException.class);
-    retrievedPageTemplate = pageTemplateService.getPageTemplate(2l, Locale.FRENCH, true);
+    retrievedPageTemplate = pageTemplateService.getPageTemplate(2l, Locale.FRENCH, true, true);
     assertNotNull(retrievedPageTemplate);
 
     reset(translationService);

--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -167,6 +167,7 @@ export default {
   methods: {
     async open(pageTemplate, duplicate, generateIllustration) {
       this.templateId = pageTemplate.id || this.$root.pageTemplate?.id || null;
+      pageTemplate = await this.$pageTemplateService.getPageTemplate(this.templateId, true);
       this.pageLayoutContent = pageTemplate.content;
       this.description = pageTemplate?.description || '';
       this.duplicate = duplicate;
@@ -200,7 +201,7 @@ export default {
       this.saving = true;
       const savePageRequest =
         (!this.duplicate && this.templateId) ?
-          this.$pageTemplateService.getPageTemplate(this.templateId)
+          this.$pageTemplateService.getPageTemplate(this.templateId, true)
             .then(pageTemplate => {
               const newTemplate = (this.$root.pageTemplate && !this.$root.pageTemplate.name);
               pageTemplate.disabled = newTemplate ? false : pageTemplate.disabled;
@@ -231,7 +232,7 @@ export default {
         .then(() => this.$refs?.pagePreview?.save())
         .then(() => {
           if (this.$root.pageTemplate) {
-            return this.$pageTemplateService.getPageTemplate(this.templateId)
+            return this.$pageTemplateService.getPageTemplate(this.templateId, true)
               .then(pageTemplate => this.$root.pageTemplate = pageTemplate);
           }
         })

--- a/layout-webapp/src/main/webapp/vue-app/common/js/PageTemplateService.js
+++ b/layout-webapp/src/main/webapp/vue-app/common/js/PageTemplateService.js
@@ -17,8 +17,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export function getPageTemplates() {
-  return fetch('/layout/rest/page/templates', {
+export function getPageTemplates(expandContent) {
+  return fetch(`/layout/rest/page/templates?expandContent=${expandContent || false}`, {
     method: 'GET',
     credentials: 'include',
   }).then(resp => {
@@ -30,8 +30,8 @@ export function getPageTemplates() {
   });
 }
 
-export function getPageTemplate(id) {
-  return fetch(`/layout/rest/page/templates/${id}`, {
+export function getPageTemplate(id, expandContent) {
+  return fetch(`/layout/rest/page/templates/${id}?expandContent=${expandContent || false}`, {
     method: 'GET',
     credentials: 'include',
   }).then(resp => {

--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/components/LayoutEditor.vue
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/components/LayoutEditor.vue
@@ -116,7 +116,7 @@ export default {
         if (this.draftPageRef) {
           this.$root.draftPageRef = this.draftPageRef;
           if (this.pageTemplateId) {
-            this.$pageTemplateService.getPageTemplate(this.pageTemplateId)
+            this.$pageTemplateService.getPageTemplate(this.pageTemplateId, true)
               .then(pageTemplate => this.$root.pageTemplate = pageTemplate)
               .then(() => this.$pageLayoutService.updatePageLayout(
                 this.draftPageRef,

--- a/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/SiteBannerSection.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/SiteBannerSection.vue
@@ -21,7 +21,7 @@
 -->
 <template>
   <page-layout-container-base
-    :container="container"
+    :container="containerToDisplay"
     :parent-id="parentId"
     class="layout-banner-section layout-section-content flex-grow-1 flex-shrink-1 full-width display-flex flex-row"
     no-background-style
@@ -39,10 +39,13 @@ export default {
       default: null,
     },
   },
-  created() {
-    if (!this.container.height) {
-      this.container.height = '57px';
-    }
+  computed: {
+    containerToDisplay() {
+      return this.container.height ? this.container : {
+        ...this.container,
+        height: '57px',
+      };
+    },
   },
 };
 </script>

--- a/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/SiteSidebarSection.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/SiteSidebarSection.vue
@@ -22,7 +22,7 @@
 <template>
   <page-layout-container-base
     v-if="childrenSize"
-    :container="container"
+    :container="containerToDisplay"
     :parent-id="parentId"
     class="flex-grow-0 flex-shrink-0 layout-sidebar-section layout-section-content"
     no-background-style
@@ -44,11 +44,12 @@ export default {
     childrenSize() {
       return this.container?.children?.length;
     },
-  },
-  created() {
-    if (!this.container.width) {
-      this.container.width = '310px';
-    }
+    containerToDisplay() {
+      return this.container.width ? this.container : {
+        ...this.container,
+        width: '310px',
+      };
+    },
   },
 };
 </script>


### PR DESCRIPTION
This change will avoid loading Page Template content when listing it only when explicitely needed through a dedicated REST parameter. In addition, this will improve performances of Page Layout retrieval by introducing the usage of eTag mechanism to return a HTTP 304 response code when not modified comparing to the version cached in user's browser.