### PR TITLE
fix: Store each Site container's Background Attachment using its id - MEED-8306 - Meeds-io/MIPs175

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-layout/components/form/BackgroundInput.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/components/form/BackgroundInput.vue
@@ -213,8 +213,11 @@ export default {
     initialized: false,
   }),
   computed: {
+    id() {
+      return this.container.storageId || this.container.id;
+    },
     objectId() {
-      return this.$root.isSiteLayout ? `site_${this.$root.siteId}_${this.pageStyle && this.$root.layout.storageId || 0}` : `page_${this.$root.pageId}_${this.container.storageId}`;
+      return this.$root.isSiteLayout ? `site_${this.$root.siteId}_${this.pageStyle && this.$root.layout.storageId || this.id}` : `page_${this.$root.pageId}_${this.id}`;
     },
     backgroundColor() {
       return this.container.backgroundColor;


### PR DESCRIPTION
Prior to this change, the Site containers attachment was using the same container's id '0'. This will lead to delete all containers attachments when modifying a background for a given container. This change will allow to make a unique attachment per container.