### PR TITLE
fix: Display Site Sidebar Layout Container in full height - MEED-8307 - Meeds-io/MIPs#175

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/SiteSidebarCell.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/SiteSidebarCell.vue
@@ -23,7 +23,7 @@
   <page-layout-container-base
     :container="containerToDisplay"
     :parent-id="parentId"
-    class="display-flex flex-column border-box-sizing layout-sidebar-cell overflow-hidden"
+    class="display-flex flex-column border-box-sizing layout-sidebar-cell fill-height overflow-hidden"
     section-style />
 </template>
 <script>


### PR DESCRIPTION
Prior to this change, the Sidebar Cell container is adjusted to applications content only. This change will allow to display the container in full width height.