### PR TITLE
fix: Fix Extra Margin In Sites Management UI - Meeds-io/MIPs#175

### DIFF
--- a/layout-webapp/src/main/webapp/WEB-INF/jsp/siteManagement.jsp
+++ b/layout-webapp/src/main/webapp/WEB-INF/jsp/siteManagement.jsp
@@ -6,7 +6,7 @@
   String defaultPortalName = userPortalConfigService.getMetaPortal();
   String globalPortalName = userPortalConfigService.getGlobalPortal();
 %>
-<div class="VuetifyApp singlePageApplication">
+<div class="VuetifyApp">
   <div id="siteManagement">
     <script type="text/javascript">
       eXo.env.portal.defaultPortalName = '<%=defaultPortalName%>';


### PR DESCRIPTION
This change will delete an extra margin added in Sites Management UI due to a deprecated class used in parent node of portlet.