### PR TITLE
fix: Fix Creating A Page Template - MEED-8341 - Meeds-io/MIPs#175

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/page-template/components/list/PageTemplates.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-template/components/list/PageTemplates.vue
@@ -195,11 +195,17 @@ export default {
         .catch(() => this.$root.$emit('alert-message', this.$t('pageTemplate.delete.error'), 'error'))
         .finally(() => this.loading = false);
     },
-    createPageTemplate() {
-      const columnsTemplate = this.pageTemplates.find(t => t.system && t.content.includes('FlexContainer'));
-      const columnsTemplateContent = columnsTemplate?.content || '{}';
-      this.$pageTemplateService.createPageTemplate(columnsTemplateContent, true)
-        .then(pageTemplate => window.open(`/portal/administration/layout-editor?pageTemplateId=${pageTemplate.id}`, '_blank'));
+    async createPageTemplate() {
+      this.loading = true;
+      try {
+        const pageTemplates = await this.$pageTemplateService.getPageTemplates(true);
+        const columnsTemplate = pageTemplates.find(t => t.system && t.content.includes('FlexContainer'));
+        const columnsTemplateContent = columnsTemplate?.content || '{}';
+        this.$pageTemplateService.createPageTemplate(columnsTemplateContent, true)
+          .then(pageTemplate => window.open(`/portal/administration/layout-editor?pageTemplateId=${pageTemplate.id}`, '_blank'));
+      } finally {
+        this.loading = false;
+      }
     },
   },
 };


### PR DESCRIPTION
Prior to this change, in order to select an existing system page template with columns configuration, the content isn't retrieved in existing templates list, thus it can't choose the adequate basic page template to use. This change will enforce to retrieve the Page Templates with its content when needed rather than relying on existing lit.