### PR TITLE
fix: Fix Creating A Page Template - MEED-8341 - Meeds-io/MIPs#175

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/page-template/components/PageTemplatesManagement.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-template/components/PageTemplatesManagement.vue
@@ -26,10 +26,12 @@
       </h4>
       <page-templates-management-toolbar
         ref="toolbar"
+        :creating="creating"
         @page-templates-filter="keyword = $event" />
       <page-templates-management-list
         ref="list"
-        :keyword="keyword" />
+        :keyword="keyword"
+        @creating="creating = $event" />
     </v-card>
     <layout-editor-page-template-drawer />
     <layout-image-illustration-preview />
@@ -40,6 +42,7 @@
 export default {
   data: () => ({
     keyword: null,
+    creating: false,
   }),
 };
 </script>

--- a/layout-webapp/src/main/webapp/vue-app/page-template/components/header/Toolbar.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-template/components/header/Toolbar.vue
@@ -33,6 +33,7 @@
         id="applicationToolbarLeftButton"
         :aria-label="$t('pageTemplates.add')"
         :class="$root.isMobile && 'px-0'"
+        :loading="creating"
         class="btn btn-primary text-truncate"
         @click="$root.$emit('page-templates-create')">
         <v-icon
@@ -50,6 +51,12 @@
 </template>
 <script>
 export default {
+  props: {
+    creating: {
+      type: Boolean,
+      default: false,
+    },
+  },
   data: () => ({
     pageTemplates: null,
   }),


### PR DESCRIPTION
Prior to this change, in order to select an existing system page template with columns configuration, the content isn't retrieved in existing templates list, thus it can't choose the adequate basic page template to use. This change will enforce to retrieve the Page Templates with its content when needed rather than relying on existing lit.