### PR TITLE
fix: Fix Site Form Save Button Disaling - MEED-8300 - Meeds-io/meeds#2850

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/site-management/components/drawer/SiteFormDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/site-management/components/drawer/SiteFormDrawer.vue
@@ -274,7 +274,7 @@ export default {
     saveDisabled() {
       return !this.siteLabel
         || !this.siteName
-        || this.sites?.find?.(s => s.name === this.siteName)
+        || (this.isNew && this.sites?.find?.(s => s.name === this.siteName))
         || !(/^[a-zA-Z0-9_-]*$/).test(this.siteName);
     },
     sortedTemplates() {


### PR DESCRIPTION
Prior to this change, the 'Save' button in site form was disabled when editing an existing site. This is due to a condition which has to be made on new site form instead of creation: Avoid duplicated site technical uri. This change will allow to enable this condition only when the Site form is opened for Site creation rather than Site editing.