### PR TITLE
feat: Add static CSS/JS apps to a dedicated site - MEED-8148 - Meeds-io/MIPs#167 (#339)

### DIFF
--- a/layout-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/layout-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -344,6 +344,7 @@
   <portlet>
     <name>SiteManagement</name>
     <module>
+      <load-group>SiteManagementGRP</load-group>
       <script>
         <minify>false</minify>
         <path>/js/siteManagement.bundle.js</path>

--- a/layout-webapp/src/main/webapp/vue-app/site-management/components/SiteManagement.vue
+++ b/layout-webapp/src/main/webapp/vue-app/site-management/components/SiteManagement.vue
@@ -45,6 +45,9 @@
     <manage-permissions-drawer />
     <site-template-drawer />
     <layout-analytics application-name="siteManagement" />
+    <extension-registry-components
+      :name="extensionApp"
+      :type="extensionDrawerType" />
   </v-app>
 </template>
 
@@ -57,18 +60,26 @@ export default {
       siteToDelete: null,
       keyword: null,
       deleteConfirmMessage: '',
+      extensionApp: 'site-management',
+      extensionActionType: 'action',
+      extensionDrawerType: 'site-management-drawers'
     };
   },
   created() {
     this.$root.$on('site-created', this.handleSiteCreation);
     this.$root.$on('site-updated', this.refreshSites);
     this.$root.$on('delete-site', this.confirmDelete);
+    document.addEventListener(`component-${this.extensionApp}-${this.extensionDrawerType}-updated`, this.refreshActionExtensions);
+    document.addEventListener(`extension-${this.extensionApp}-${this.extensionActionType}-updated`, this.refreshActionExtensions);
     this.refreshSites();
+    this.refreshActionExtensions();
   },
-  beforDestroy() {
+  beforeDestroy() {
     this.$root.$off('site-created', this.handleSiteCreation);
     this.$root.$off('site-updated', this.refreshSites);
     this.$root.$on('delete-site', this.confirmDelete);
+    document.removeEventListener(`component-${this.extensionApp}-${this.extensionDrawerType}-updated`, this.refreshActionExtensions);
+    document.removeEventListener(`component-${this.extensionApp}-${this.extensionActionType}-updated`, this.refreshActionExtensions);
   },
   methods: {
     handleSiteCreation(site) {
@@ -91,6 +102,9 @@ export default {
       })
         .then(sites => this.sites = sites?.filter(s => !s?.properties?.IS_SPACE_PUBLIC_SITE) || [])
         .finally(() => this.loading--);
+    },
+    refreshActionExtensions() {
+      this.$root.siteActionExtensions = extensionRegistry.loadExtensions(this.extensionApp, this.extensionActionType) || [];
     },
     confirmDelete(siteToDelete) {
       this.siteToDelete = siteToDelete;

--- a/layout-webapp/src/main/webapp/vue-app/site-management/components/main/Menu.vue
+++ b/layout-webapp/src/main/webapp/vue-app/site-management/components/main/Menu.vue
@@ -72,6 +72,25 @@
         <span>{{ noLayoutEditTooltip }}</span>
       </v-tooltip>
       <v-list-item
+        v-for="extension in extensions"
+        :key="extension.id"
+        class="px-3"
+        @click="handelAction(extension)">
+        <v-card
+          color="transparent"
+          min-width="15"
+          class="me-2"
+          flat>
+          <v-icon size="13">
+            {{ extension?.icon }}
+          </v-icon>
+        </v-card>
+        <v-list-item-title
+          class="subtitle-2">
+          <span class="ps-1">{{ $t(extension.labelKey) }}</span>
+        </v-list-item-title>
+      </v-list-item>
+      <v-list-item
         v-if="isPortalSite && !isGlobalSite"
         :aria-label="$t('siteManagement.label.properties')"
         role="button"
@@ -238,9 +257,6 @@ export default {
     loading: false,
   }),
   computed: {
-    isMetaSite() {
-      return this.site.name === eXo.env.portal.defaultPortal;
-    },
     isGlobalSite() {
       return this.site.name === 'global';
     },
@@ -272,6 +288,9 @@ export default {
       return (this.isMetaSite || this.isGlobalSite)
         ? this.$t('sites.label.system.noLayoutEdit')
         : this.$t('sites.label.meta.noLayoutEdit');
+    },
+    extensions() {
+      return this.$root.siteActionExtensions || [];
     },
   },
   watch: {
@@ -350,6 +369,9 @@ export default {
         this.loading = false;
       }
     },
+    handelAction(extension) {
+      return extension?.action(this, this.site);
+    }
   }
 };
 </script>

--- a/layout-webapp/src/main/webapp/vue-app/site-management/main.js
+++ b/layout-webapp/src/main/webapp/vue-app/site-management/main.js
@@ -61,5 +61,6 @@ export function init() {
           },
         },
       }, `#${appId}`, 'site-management');
-    });
+    }).finally(() => Vue.prototype.$utils?.includeExtensions?.('SiteManagementExtension'));
+
 }


### PR DESCRIPTION
This PR will implement a new feature that will allow the admin to add js/css applications to a dedicated site via a new drawer component