### PR TITLE
fix: Fix Impersonating Addon Containers - MEED-8349 - Meeds-io/meeds#2894

### DIFF
--- a/layout-service/src/test/java/io/meeds/layout/service/PageLayoutServiceTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/service/PageLayoutServiceTest.java
@@ -184,6 +184,10 @@ public class PageLayoutServiceTest {
     pageLayoutService.impersonateSite(SITE_KEY);
 
     verify(containerLayoutService).impersonateContainer(container, page);
+    verify(layoutService, never()).save(state, preferences);
+
+    when(application.getStorageId()).thenReturn("2");
+    pageLayoutService.impersonateSite(SITE_KEY);
     verify(layoutService).save(state, preferences);
   }
 


### PR DESCRIPTION
Prior to this change, when creating a site **from a template** where we have an `addon container` defined into it with a declared application, then the impersonation process of created site will consider container's children and will attempt to store in database its preferences. This change will ensure to **ignore** `addon container` children which doesn't have a dedicated `StorageId` where to store preferences.