### PR TITLE
fix: Enable Navigation Drawer in Site Templates - MEED-8432 - Meeds-io/meeds#2950

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/site-template/main.js
+++ b/layout-webapp/src/main/webapp/vue-app/site-template/main.js
@@ -19,7 +19,7 @@
 
 import './initComponents.js';
 import '../common-layout/services.js';
-
+import '../common-sites/main.js';
 import '../common-illustration/main.js';
 import '../common-site-template/main.js';
 


### PR DESCRIPTION
Prior to this change, when clicking on 'edit navigation' button, the navigation drawer isn't displayed. This change will import Navigation Drawer Vue components in Site Template UI.

Resolves Meeds-io/meeds#2950