### PR TITLE
feat: Review Space Directory Portlet Instances Default Permissions - MEED-8435 - Meeds-io/MIPs#178

### DIFF
--- a/layout-service/src/main/resources/portlet-instances.json
+++ b/layout-service/src/main/resources/portlet-instances.json
@@ -440,8 +440,7 @@
       },
       "illustrationPath":"war:/../images/portlets/SpacesDirectory.webp",
       "permissions":[
-        "*:/platform/administrators",
-        "*:/platform/web-contributors"
+        "*:/platform/administrators"
       ],
       "system":true
     }


### PR DESCRIPTION
This change will make `Space Directory` portlet instance visible for administrators only when editing their layout