### PR TITLE
fix: Save Edited Page Template - MEED-8460 - Meeds-io/meeds#2983

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -165,12 +165,15 @@ export default {
     this.$root.$off('layout-page-template-drawer-open', this.open);
   },
   methods: {
-    async open(pageTemplate, duplicate, generateIllustration) {
-      this.templateId = pageTemplate.id || this.$root.pageTemplate?.id || null;
-      pageTemplate = await this.$pageTemplateService.getPageTemplate(this.templateId, true);
-      this.pageLayoutContent = pageTemplate.content;
+    async open(template, duplicate, generateIllustration) {
+      this.templateId = template.id || this.$root.pageTemplate?.id || null;
+      this.pageLayoutContent = template.content;
+      const pageTemplate = await this.$pageTemplateService.getPageTemplate(this.templateId, true);
       this.description = pageTemplate?.description || '';
       this.duplicate = duplicate;
+      if (this.duplicate) {
+        this.pageLayoutContent = pageTemplate.content;
+      }
       if (generateIllustration) {
         const parentElement = document.querySelector('.layout-sections-parent .layout-page-body').parentElement;
         parentElement.querySelectorAll('.layout-add-application-button').forEach(el => el.style.display = 'none');


### PR DESCRIPTION
Prior to this change, when saving a page after editing it, the updates aren't saved. This change ensure to use the generated content by editor rather than resetting the original content coming from store.

fixes Meeds-io/meeds#2983