### PR TITLE
feat: Add Spaces Directory Settings Preference Plugin - MEED-8481 - Meeds-io/meeds#3009

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/plugin/renderer/SpaceDirectoryPortletInstancePreferencePlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/renderer/SpaceDirectoryPortletInstancePreferencePlugin.java
@@ -1,0 +1,58 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.layout.plugin.renderer;
+
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.portal.config.model.Application;
+import org.exoplatform.portal.pom.spi.portlet.Portlet;
+
+import io.meeds.layout.model.PortletInstancePreference;
+import io.meeds.layout.plugin.PortletInstancePreferencePlugin;
+
+import lombok.SneakyThrows;
+
+@Service
+public class SpaceDirectoryPortletInstancePreferencePlugin implements PortletInstancePreferencePlugin {
+
+  private static final String SETTING_PREFERENCE_NAME = "name";
+
+  @Override
+  public String getPortletName() {
+    return "SpacesList";
+  }
+
+  @Override
+  @SneakyThrows
+  public List<PortletInstancePreference> generatePreferences(Application application, Portlet preferences) {
+    return StreamSupport.stream(preferences.spliterator(), false)
+                        // remove generated setting name for the original
+                        // instance to avoid duplicating instances using the
+                        // same setting name
+                        .filter(p -> !StringUtils.equals(SETTING_PREFERENCE_NAME, p.getName()))
+                        .map(p -> new PortletInstancePreference(p.getName(), p.getValue()))
+                        .toList();
+  }
+
+}

--- a/layout-service/src/test/java/io/meeds/layout/plugin/renderer/SpaceDirectoryPortletInstancePreferencePluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/renderer/SpaceDirectoryPortletInstancePreferencePluginTest.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.layout.plugin.renderer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.exoplatform.portal.pom.spi.portlet.Portlet;
+import org.exoplatform.portal.pom.spi.portlet.Preference;
+
+import io.meeds.layout.model.PortletInstancePreference;
+
+@SpringBootTest(classes = {
+  SpaceDirectoryPortletInstancePreferencePlugin.class,
+})
+@ExtendWith(MockitoExtension.class)
+public class SpaceDirectoryPortletInstancePreferencePluginTest {
+
+  private static final String OTHER_PREF_NAME = "name2";
+  private static final String SETTING_NAME = "name";
+  @Autowired
+  private SpaceDirectoryPortletInstancePreferencePlugin spaceDirectoryPortletInstancePreferencePlugin;
+
+  @Test
+  void getPortletName() {
+    assertEquals("SpacesList", spaceDirectoryPortletInstancePreferencePlugin.getPortletName());
+  }
+
+  @Test
+  void generatePreferences() {
+    Map<String, Preference> map = new HashMap<>();
+    map.put(SETTING_NAME, new Preference(SETTING_NAME, "value", false));
+    map.put(OTHER_PREF_NAME, new Preference(OTHER_PREF_NAME, "value", false));
+    Portlet preferences = new Portlet(map);
+    List<PortletInstancePreference> generatedPreferences = spaceDirectoryPortletInstancePreferencePlugin.generatePreferences(null, preferences);
+    assertNotNull(generatedPreferences);
+    assertEquals(1, generatedPreferences.size());
+    assertEquals(OTHER_PREF_NAME, generatedPreferences.get(0).getName());
+  }
+
+}

--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -168,11 +168,13 @@ export default {
     async open(template, duplicate, generateIllustration) {
       this.templateId = template.id || this.$root.pageTemplate?.id || null;
       this.pageLayoutContent = template.content;
-      const pageTemplate = await this.$pageTemplateService.getPageTemplate(this.templateId, true);
-      this.description = pageTemplate?.description || '';
-      this.duplicate = duplicate;
-      if (this.duplicate) {
-        this.pageLayoutContent = pageTemplate.content;
+      if (this.templateId) {
+        const pageTemplate = await this.$pageTemplateService.getPageTemplate(this.templateId, true);
+        this.description = pageTemplate?.description || '';
+        this.duplicate = duplicate;
+        if (this.duplicate) {
+          this.pageLayoutContent = pageTemplate.content;
+        }
       }
       if (generateIllustration) {
         const parentElement = document.querySelector('.layout-sections-parent .layout-page-body').parentElement;


### PR DESCRIPTION
This change will add a plugin in order to filter exported data when duplicating a 'Spaces Directory' portlet instance in order to avoid having two portlet instances having the same setting name.