### PR TITLE
fix: Enhance Access to Layout Editor Section Buttons - MEED-8591 - Meeds-io/meeds#3109

### DIFF
--- a/layout-webapp/src/main/webapp/skin/less/editor.less
+++ b/layout-webapp/src/main/webapp/skin/less/editor.less
@@ -118,11 +118,15 @@
   .layout-section-hover {
     border: thin solid @greyColorOpacity2 !important;
   }
-  &:first-of-type .layout-section-hover {
+  &:first-of-type .layout-section-border {
     margin-top: 12px;
+    height: ~"calc(100% - 12px)";
   }
   &:last-of-type {
     padding-bottom: var(--allPagesMarginBottom, 20px) !important;
+    .layout-section-border {
+      height: ~"calc(100% - var(--allPagesMarginBottom, 20px) / 2)";
+    }
   }
   &.layout-moving-chosen-container {
     > div {

--- a/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenu.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenu.vue
@@ -22,152 +22,12 @@
   <div
     v-show="displayBorder"
     :class="moving && 'layout-section-moving' || 'layout-section-hover'"
-    class="absolute-full-size layout-no-multi-select border-radius">
+    class="layout-no-multi-select border-radius">
     <v-slide-y-transition>
       <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
       <div
         v-if="open"
-        class="position-relative full-width full-height d-flex flex-column"
-        @focusin="hoverArea = true"
-        @mouseover="hoverArea = true"
-        @focusout="hoverArea = false"
-        @mouseout="hoverArea = false">
-        <v-hover v-model="hoverButton1">
-          <div :class="!hoveredApplication && 'z-index-two'" class="position-sticky d-flex justify-center mb-auto mt-n4">
-            <v-tooltip bottom>
-              <template #activator="{on, attrs}">
-                <div
-                  v-on="on"
-                  v-bind="attrs">
-                  <v-btn
-                    v-if="!$root.noSectionAdd"
-                    class="white text-color border-color elevation-2"
-                    height="32"
-                    width="32"
-                    icon
-                    @click="$root.$emit('layout-add-section-drawer', index)">
-                    <v-icon class="icon-default-color" size="20">fa-plus</v-icon>
-                  </v-btn>
-                </div>
-              </template>
-              {{ $t('layout.addSectionBefore') }}
-            </v-tooltip>
-          </div>
-        </v-hover>
-        <v-hover
-          v-if="displayMoveButton"
-          v-model="hoverButton2">
-          <div
-            :style="leftButtonStyle"
-            class="position-absolute t-10 z-index-one full-height">
-            <div class="position-sticky t-20 z-index-one">
-              <v-tooltip :disabled="moving" bottom>
-                <template #activator="{on, attrs}">
-                  <div
-                    v-on="on"
-                    v-bind="attrs">
-                    <v-btn
-                      v-if="!$root.noSectionAdd"
-                      class="white text-color border-color elevation-2 draggable"
-                      height="32"
-                      width="32"
-                      icon
-                      @mousedown="$emit('move-start')"
-                      @mouseup="$emit('move-end')"
-                      @mouseout="$emit('move-end')"
-                      @focusout="$emit('move-end')">
-                      <v-icon class="icon-default-color" size="20">fa-arrows-alt</v-icon>
-                    </v-btn>
-                  </div>
-                </template>
-                {{ $t('layout.moveSection') }}
-              </v-tooltip>
-            </div>
-          </div>
-        </v-hover>
-        <v-hover v-model="hoverButton3">
-          <div
-            :style="rightButtonStyle"
-            class="position-absolute t-10 z-index-one full-height">
-            <div class="position-sticky t-20 z-index-one">
-              <v-tooltip bottom>
-                <template #activator="{on, attrs}">
-                  <div
-                    v-on="on"
-                    v-bind="attrs">
-                    <v-btn
-                      class="white text-color border-color elevation-2"
-                      height="32"
-                      width="32"
-                      icon
-                      @click="$root.$emit('layout-edit-section-drawer', index, length)">
-                      <v-icon class="icon-default-color" size="20">fa-edit</v-icon>
-                    </v-btn>
-                  </div>
-                </template>
-                {{ $t('layout.editSection') }}
-              </v-tooltip>
-              <v-tooltip v-if="$root.isAdministrator" bottom>
-                <template #activator="{on, attrs}">
-                  <div
-                    v-on="on"
-                    v-bind="attrs">
-                    <v-btn
-                      :aria-label="$t('layout.cloneSection')"
-                      class="white text-color border-color elevation-2 mt-2"
-                      height="32"
-                      width="32"
-                      icon
-                      @click="$root.$emit('layout-section-clone', container, index)">
-                      <v-icon class="icon-default-color" size="20">fa-copy</v-icon>
-                    </v-btn>
-                  </div>
-                </template>
-                {{ $t('layout.cloneSection') }}
-              </v-tooltip>
-              <v-tooltip v-if="$root.isAdministrator" bottom>
-                <template #activator="{on, attrs}">
-                  <div
-                    v-on="on"
-                    v-bind="attrs">
-                    <v-btn
-                      :loading="savingAsTemplate"
-                      class="white text-color border-color elevation-2 mt-2"
-                      height="32"
-                      width="32"
-                      icon
-                      @click="saveAsTemplate">
-                      <v-icon class="icon-default-color" size="20">fa-columns</v-icon>
-                    </v-btn>
-                  </div>
-                </template>
-                {{ $t('layout.saveAsSectionTemplate') }}
-              </v-tooltip>
-            </div>
-          </div>
-        </v-hover>
-        <v-hover v-model="hoverButton4">
-          <div class="position-sticky z-index-two d-flex justify-center mb-n4 mt-auto">
-            <v-tooltip top>
-              <template #activator="{on, attrs}">
-                <div
-                  v-on="on"
-                  v-bind="attrs">
-                  <v-btn
-                    v-if="!$root.noSectionAdd"
-                    class="white text-color border-color elevation-2"
-                    height="32"
-                    width="32"
-                    icon
-                    @click="$root.$emit('layout-add-section-drawer', index + 1)">
-                    <v-icon class="icon-default-color" size="20">fa-plus</v-icon>
-                  </v-btn>
-                </div>
-              </template>
-              {{ $t('layout.addSectionAfter') }}
-            </v-tooltip>
-          </div>
-        </v-hover>
+        class="position-relative full-width full-height d-flex flex-column z-index-two">
       </div>
     </v-slide-y-transition>
   </div>
@@ -198,38 +58,10 @@ export default {
   },
   data: () => ({
     open: false,
-    savingAsTemplate: false,
-    hoverButton1: false,
-    hoverButton2: false,
-    hoverButton3: false,
-    hoverButton4: false,
-    hoverArea: false,
   }),
   computed: {
-    hoverButton() {
-      return this.hoverButton1 || this.hoverButton2 || this.hoverButton3 || this.hoverButton4;
-    },
-    displayMoveButton() {
-      return this.length > 1;
-    },
     displayBorder() {
       return this.open || this.hover;
-    },
-    hoveredSectionMenu() {
-      return this.hoverButton || (!this.hoverArea && !this.hoveredApplication);
-    },
-    hoveredApplication() {
-      return this.$root.hoveredApplication;
-    },
-    leftButtonStyle() {
-      return {
-        left: '-20px',
-      };
-    },
-    rightButtonStyle() {
-      return {
-        right: '-20px',
-      };
     },
   },
   watch: {
@@ -239,9 +71,6 @@ export default {
           this.open = this.hover;
         }
       }, 200);
-    },
-    hoveredSectionMenu() {
-      this.$emit('hover-button', this.hoveredSectionMenu);
     },
     moving() {
       window.setTimeout(() => {
@@ -256,23 +85,6 @@ export default {
       } else if (!newVal && this.$root.hoveredSectionId === this.container.storageId) {
         this.$root.hoveredSectionId = null;
       }
-    },
-  },
-  methods: {
-    async saveAsTemplate() {
-      this.savingAsTemplate = true;
-      await this.$nextTick();
-      window.setTimeout(() => {
-        this.savingAsTemplate = false;
-        this.open = false;
-        try {
-          this.$root.$emit('layout-section-save-as-template', this.container);
-        } finally {
-          window.setTimeout(() => {
-            this.savingAsTemplate = false;
-          }, 2000);
-        }
-      }, 200);
     },
   },
 };

--- a/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenuBottom.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenuBottom.vue
@@ -1,0 +1,87 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-hover v-model="hoverButton" :disabled="$root.mobileDisplayMode">
+    <div>
+      <v-slide-y-transition>
+        <div
+          v-if="display || hoverButton"
+          :class="lastSection && 'mb-n2' || 'mb-n4'"
+          class="absolute-horizontal-center b-0 d-flex justify-center z-index-two">
+          <v-tooltip top>
+            <template #activator="{on, attrs}">
+              <div
+                v-on="on"
+                v-bind="attrs">
+                <v-btn
+                  v-if="!$root.noSectionAdd"
+                  class="white text-color border-color elevation-2"
+                  height="32"
+                  width="32"
+                  icon
+                  @click="$root.$emit('layout-add-section-drawer', index + 1)">
+                  <v-icon class="icon-default-color" size="20">fa-plus</v-icon>
+                </v-btn>
+              </div>
+            </template>
+            {{ $t('layout.addSectionAfter') }}
+          </v-tooltip>
+        </div>
+      </v-slide-y-transition>
+    </div>
+  </v-hover>
+</template>
+<script>
+export default {
+  props: {
+    value: {
+      type: Object,
+      default: null,
+    },
+    index: {
+      type: Number,
+      default: null,
+    },
+    length: {
+      type: Number,
+      default: null,
+    },
+    display: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    lastSection() {
+      return this.index === this.length -1;
+    },
+    hoverButton: {
+      get () {
+        return this.value;
+      },
+      set (value) {
+        this.$emit('input', value);
+      },
+    },
+  }
+};
+</script>

--- a/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenuLeft.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenuLeft.vue
@@ -1,0 +1,107 @@
+
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-hover v-model="hoverButton" :disabled="$root.mobileDisplayMode">
+    <div
+      v-show="display || hoverButton"
+      :style="leftButtonStyle"
+      class="position-absolute t-10 full-height justify-center z-index-two">
+      <div class="position-relative full-height">
+        <div class="position-sticky t-20 z-index-one">
+          <v-tooltip :disabled="moving" bottom>
+            <template #activator="{on, attrs}">
+              <div
+                v-on="on"
+                v-bind="attrs">
+                <v-btn
+                  v-if="!$root.noSectionAdd"
+                  class="white text-color border-color elevation-2 draggable"
+                  height="32"
+                  width="32"
+                  icon
+                  @mousedown="$emit('move-start')"
+                  @mouseup="$emit('move-end')"
+                  @mouseout="$emit('move-end')"
+                  @focusout="$emit('move-end')">
+                  <v-icon class="icon-default-color" size="20">fa-arrows-alt</v-icon>
+                </v-btn>
+              </div>
+            </template>
+            {{ $t('layout.moveSection') }}
+          </v-tooltip>
+        </div>
+      </div>
+    </div>
+  </v-hover>
+</template>
+<script>
+export default {
+  props: {
+    value: {
+      type: Object,
+      default: null,
+    },
+    display: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data: () => ({
+    open: false,
+    savingAsTemplate: false,
+    hoverArea: false,
+  }),
+  computed: {
+    hoverButton: {
+      get () {
+        return this.value;
+      },
+      set (value) {
+        this.$emit('input', value);
+      },
+    },
+    leftButtonStyle() {
+      return {
+        left: 'calc(50% - min(50%, var(--allPagesWidth, 1320px) / 2) - 16px)',
+      };
+    },
+  },
+  methods: {
+    async saveAsTemplate() {
+      this.savingAsTemplate = true;
+      await this.$nextTick();
+      window.setTimeout(() => {
+        this.savingAsTemplate = false;
+        this.open = false;
+        try {
+          this.$root.$emit('layout-section-save-as-template', this.container);
+        } finally {
+          window.setTimeout(() => {
+            this.savingAsTemplate = false;
+          }, 2000);
+        }
+      }, 200);
+    },
+  },
+};
+</script>

--- a/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenuRight.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenuRight.vue
@@ -1,0 +1,116 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-hover v-model="hoverButton" :disabled="$root.mobileDisplayMode">
+    <div
+      v-show="display || hoverButton"
+      :style="rightButtonStyle"
+      class="position-absolute t-10 full-height justify-center z-index-two">
+      <div class="position-relative full-height">
+        <div class="position-sticky t-20 z-index-one">
+          <v-tooltip bottom>
+            <template #activator="{on, attrs}">
+              <div
+                v-on="on"
+                v-bind="attrs">
+                <v-btn
+                  class="white text-color border-color elevation-2"
+                  height="32"
+                  width="32"
+                  icon
+                  @click="$root.$emit('layout-edit-section-drawer', index, length)">
+                  <v-icon class="icon-default-color" size="20">fa-edit</v-icon>
+                </v-btn>
+              </div>
+            </template>
+            {{ $t('layout.editSection') }}
+          </v-tooltip>
+          <v-tooltip v-if="$root.isAdministrator" bottom>
+            <template #activator="{on, attrs}">
+              <div
+                v-on="on"
+                v-bind="attrs">
+                <v-btn
+                  :aria-label="$t('layout.cloneSection')"
+                  class="white text-color border-color elevation-2 mt-2"
+                  height="32"
+                  width="32"
+                  icon
+                  @click="$root.$emit('layout-section-clone', container, index)">
+                  <v-icon class="icon-default-color" size="20">fa-copy</v-icon>
+                </v-btn>
+              </div>
+            </template>
+            {{ $t('layout.cloneSection') }}
+          </v-tooltip>
+          <v-tooltip v-if="$root.isAdministrator" bottom>
+            <template #activator="{on, attrs}">
+              <div
+                v-on="on"
+                v-bind="attrs">
+                <v-btn
+                  :loading="savingAsTemplate"
+                  class="white text-color border-color elevation-2 mt-2"
+                  height="32"
+                  width="32"
+                  icon
+                  @click="saveAsTemplate">
+                  <v-icon class="icon-default-color" size="20">fa-columns</v-icon>
+                </v-btn>
+              </div>
+            </template>
+            {{ $t('layout.saveAsSectionTemplate') }}
+          </v-tooltip>
+        </div>
+      </div>
+    </div>
+  </v-hover>
+</template>
+<script>
+export default {
+  props: {
+    value: {
+      type: Object,
+      default: null,
+    },
+    display: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    hoverButton: {
+      get () {
+        return this.value;
+      },
+      set (value) {
+        this.$emit('input', value);
+      },
+    },
+    rightButtonStyle() {
+      return {
+        right: 'calc(50% - min(50%, var(--allPagesWidth, 1320px) / 2) - 16px)',
+      };
+    },
+  }
+};
+</script>

--- a/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenuTop.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/common/SectionMenuTop.vue
@@ -1,0 +1,80 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-hover v-model="hoverButton" :disabled="$root.mobileDisplayMode">
+    <div>
+      <v-slide-y-transition>
+        <div
+          v-if="display || hoverButton"
+          :class="index && 'mt-n4' || 'mt-n1'"
+          class="absolute-horizontal-center t-0 d-flex justify-center z-index-two">
+          <v-tooltip bottom>
+            <template #activator="{on, attrs}">
+              <div
+                v-on="on"
+                v-bind="attrs">
+                <v-btn
+                  v-if="!$root.noSectionAdd"
+                  class="white text-color border-color elevation-2"
+                  height="32"
+                  width="32"
+                  icon
+                  @click="$root.$emit('layout-add-section-drawer', index)">
+                  <v-icon class="icon-default-color" size="20">fa-plus</v-icon>
+                </v-btn>
+              </div>
+            </template>
+            {{ $t('layout.addSectionBefore') }}
+          </v-tooltip>
+        </div>
+      </v-slide-y-transition>
+    </div>
+  </v-hover>
+</template>
+<script>
+export default {
+  props: {
+    value: {
+      type: Object,
+      default: null,
+    },
+    index: {
+      type: Number,
+      default: null,
+    },
+    display: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    hoverButton: {
+      get () {
+        return this.value;
+      },
+      set (value) {
+        this.$emit('input', value);
+      },
+    },
+  }
+};
+</script>

--- a/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/container/Section.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/components/content/container/Section.vue
@@ -28,26 +28,29 @@
     v-on="!isDynamicSection && {
       'mousedown': startSelection,
     }">
+    <layout-editor-section-menu-top
+      v-model="hoverButton1"
+      :index="index"
+      :display="hoverSectionMenu" />
+    <layout-editor-section-menu-left
+      v-model="hoverButton2"
+      :display="hoverSectionMenu && displayMoveButton"
+      @mousedown="$emit('move-start')"
+      @mouseup="$emit('move-end')"
+      @mouseout="$emit('move-end')"
+      @focusout="$emit('move-end')" />
     <v-hover v-model="hover" :disabled="$root.mobileDisplayMode">
-      <div
+      <layout-editor-section-menu
+        :container="container"
+        :hover="hoverSectionMenu"
+        :index="index"
+        :length="length"
+        :moving="movingSection"
         :class="{
-          'z-index-two': hoverSectionMenuButton,
           'normal-page-width': !$root.pageFullWindow,
           'full-page-width': $root.pageFullWindow,
         }"
-        class="layout-section-border">
-        <div class="position-relative full-height full-width">
-          <layout-editor-section-menu
-            :container="container"
-            :hover="hoverSectionMenu"
-            :index="index"
-            :length="length"
-            :moving="movingSection"
-            @hover-button="hoverSectionMenuButton = $event"
-            @move-start="movingSection = true"
-            @move-end="movingSection = false" />
-        </div>
-      </div>
+        class="layout-section-border" />
     </v-hover>
     <layout-editor-container-base
       ref="container"
@@ -68,6 +71,15 @@
           @hide="$root.movingParentId = null" />
       </template>
     </layout-editor-container-base>
+    <layout-editor-section-menu-right
+      v-model="hoverButton3"
+      :display="hoverSectionMenu" />
+    <layout-editor-section-menu-bottom
+      v-model="hoverButton4"
+      :display="hoverSectionMenu"
+      :index="index"
+      :length="length" />
+
     <layout-section-mobile-column-menu-drawer
       v-if="mobileInColumns"
       v-model="mobileSectionColumnClass"
@@ -96,6 +108,10 @@ export default {
   },
   data: () => ({
     hover: false,
+    hoverButton1: false,
+    hoverButton2: false,
+    hoverButton3: false,
+    hoverButton4: false,
     hoverSection: false,
     hoverSectionMenuButton: false,
     movingSection: false,
@@ -115,8 +131,11 @@ export default {
     isDynamicSection() {
       return this.container.template === this.$layoutUtils.flexTemplate;
     },
+    hoverButton() {
+      return this.hoverButton1 || this.hoverButton2 || this.hoverButton3 || this.hoverButton4;
+    },
     hoverSectionMenu() {
-      return !this.drawerOpened && (this.hover || this.hoverSection || this.movingSection);
+      return !this.drawerOpened && (this.hover || this.hoverButton || this.hoverSection || this.movingSection);
     },
     cssStyle() {
       return this.$applicationUtils.getStyle(this.container, {
@@ -128,6 +147,9 @@ export default {
       return this.isDynamicSection
         && this.$root.mobileDisplayMode
         && this.container?.cssClass?.includes?.('layout-mobile-columns');
+    },
+    displayMoveButton() {
+      return this.length > 1;
     },
   },
   watch: {

--- a/layout-webapp/src/main/webapp/vue-app/common-layout/initComponents.js
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/initComponents.js
@@ -33,6 +33,10 @@ import ContainerExtension from './components/content/base/ContainerExtension.vue
 import ContainerBase from './components/content/base/ContainerBase.vue';
 
 import SectionMenu from './components/content/common/SectionMenu.vue';
+import SectionMenuTop from './components/content/common/SectionMenuTop.vue';
+import SectionMenuBottom from './components/content/common/SectionMenuBottom.vue';
+import SectionMenuLeft from './components/content/common/SectionMenuLeft.vue';
+import SectionMenuRight from './components/content/common/SectionMenuRight.vue';
 import SectionSelectionGrid from './components/content/common/SectionSelectionGrid.vue';
 import SectionSelectionGridCell from './components/content/common/SectionSelectionGridCell.vue';
 import ApplicationCategoryCard from './components/content/common/ApplicationCategoryCard.vue';
@@ -68,6 +72,10 @@ const components = {
   'layout-editor-section-selection-grid': SectionSelectionGrid,
   'layout-editor-section-selection-grid-cell': SectionSelectionGridCell,
   'layout-editor-section-menu': SectionMenu,
+  'layout-editor-section-menu-top': SectionMenuTop,
+  'layout-editor-section-menu-bottom': SectionMenuBottom,
+  'layout-editor-section-menu-left': SectionMenuLeft,
+  'layout-editor-section-menu-right': SectionMenuRight,
   'layout-editor-application-category-select-drawer': SelectApplicationCategoryDrawer,
   'layout-editor-application-add-drawer': AddApplicationDrawer,
   'layout-editor-application-edit-drawer': EditApplicationDrawer,


### PR DESCRIPTION
Prior to this change, when accessing to section menus in the right, top, left or bottom, then sometimes the buttons aren't clickable. At the same time, sometimes the section content becomes inaccessible neither. This change will adapt the section body structure in edit mode in order to avoid displaying a whole block on top of section content when hovered.