### PR TITLE
Fix: User Profile card not displayed when editing page layout - EXO-78611

### DIFF
--- a/layout-webapp/.eslintrc.json
+++ b/layout-webapp/.eslintrc.json
@@ -3,7 +3,8 @@
     "eslint-config-meedsio"
   ],
   "globals": {
-    "html2canvas": true
+    "html2canvas": true,
+    "webConferencing": true
   },
   "rules": {
     "vue/multi-word-component-names": "off",


### PR DESCRIPTION
Prior to this fix, the web conferencing API isn't retrieved on time to mark it as available for layout editor.
Thus, this change will fix retrieving the Web Conferencing API through a Promise to make sure to retrieve in async way the Web conferencing API.