### PR TITLE
fix: Fix Access to Portlets List From Layout Editor - MEED-9140 - Meeds-io/meeds#3333

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/rest/PortletRest.java
+++ b/layout-service/src/main/java/io/meeds/layout/rest/PortletRest.java
@@ -43,16 +43,10 @@ public class PortletRest {
   private PortletService portletService;
 
   @GetMapping
-  @Secured({
-             "administrators",
-             "web-contributors",
-  })
-  @Operation(
-             summary = "Retrieve portlets",
-             method = "GET",
-             description = "This retrieves the list of available portlets in the platform")
+  @Secured("users")
+  @Operation(summary = "Retrieve portlets", method = "GET", description = "This retrieves the list of available portlets in the platform")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
   })
   public List<PortletDescriptor> getPortlets() {
     return portletService.getPortlets();

--- a/layout-service/src/test/java/io/meeds/layout/rest/PortletRestTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/rest/PortletRestTest.java
@@ -87,34 +87,10 @@ public class PortletRestTest {
   }
 
   @Test
-  void getPortletsWithContributor() throws Exception {
-    ResultActions response = mockMvc.perform(get(REST_PATH).with(testContributorUser()));
-    response.andExpect(status().isOk());
-    verify(portletService).getPortlets();
-  }
-
-  @Test
-  void getPortletsWithAdmin() throws Exception {
-    ResultActions response = mockMvc.perform(get(REST_PATH).with(testAdminUser()));
-    response.andExpect(status().isOk());
-    verify(portletService).getPortlets();
-  }
-
-  @Test
   void getPortletsWithSimple() throws Exception {
     ResultActions response = mockMvc.perform(get(REST_PATH).with(testSimpleUser()));
-    response.andExpect(status().isForbidden());
-    verifyNoInteractions(portletService);
-  }
-
-  private RequestPostProcessor testContributorUser() {
-    return user(SIMPLE_USER).password(TEST_PASSWORD)
-                            .authorities(new SimpleGrantedAuthority("web-contributors"));
-  }
-
-  private RequestPostProcessor testAdminUser() {
-    return user(SIMPLE_USER).password(TEST_PASSWORD)
-                            .authorities(new SimpleGrantedAuthority("administrators"));
+    response.andExpect(status().isOk());
+    verify(portletService).getPortlets();
   }
 
   private RequestPostProcessor testSimpleUser() {


### PR DESCRIPTION
Prior to this change, the access to portlets list was reserved to administrators and web contributors only. This change will allow all users to access this list in order to allow them to edit pages of their spaces they manage.

Resolves Meeds-io/meeds#3333