### PR TITLE
fix: Upgrade Hibernate to version 6.6 - Meeds-io/meeds#3365

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/util/EntityMapper.java
+++ b/layout-service/src/main/java/io/meeds/layout/util/EntityMapper.java
@@ -271,7 +271,7 @@ public class EntityMapper {
   }
 
   public static SectionTemplateEntity toEntity(SectionTemplate sectionTemplate) {
-    return new SectionTemplateEntity(sectionTemplate.getId(),
+    return new SectionTemplateEntity(sectionTemplate.getId() == 0 ? null : sectionTemplate.getId(),
                                      sectionTemplate.getCategory(),
                                      sectionTemplate.getContent(),
                                      sectionTemplate.isSystem(),


### PR DESCRIPTION
Hibernate may cause a problem when creating an entity with 0 as id instead of null. This change ensures to set id to null instead of 0 in case of entity creation.