### PR TITLE
feat: Allow to restore a Builtin Space Template Page Layouts - MEED-9221 - Meeds-io/meeds#3350

### DIFF
--- a/layout-webapp/src/main/resources/locale/portlet/SiteNavigation_en.properties
+++ b/layout-webapp/src/main/resources/locale/portlet/SiteNavigation_en.properties
@@ -130,3 +130,4 @@ sites.permission.guests=Guests
 sites.permission.groupMembers=Group Members
 sites.permission.everyone=Any
 sites.saveAsSiteTemplate=Save as template
+spaceTemplate.label.restoreDefaultPages=Restore Default Pages

--- a/layout-webapp/src/main/webapp/vue-app/site-navigation/components/SpaceTemplateRestoreDefaultPagesSpaceMenuItem.vue
+++ b/layout-webapp/src/main/webapp/vue-app/site-navigation/components/SpaceTemplateRestoreDefaultPagesSpaceMenuItem.vue
@@ -2,7 +2,7 @@
 
   This file is part of the Meeds project (https://meeds.io/).
 
-  Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+  Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -21,14 +21,14 @@
 -->
 <template>
   <v-list-item
-    v-if="spaceTemplate?.layout"
+    v-if="spaceTemplate?.system"
     dense
-    @click="openSiteNavigationDrawer">
+    @click="restoreDefaultPages">
     <v-icon size="13">
-      fa-columns
+      fa-redo
     </v-icon>
     <v-list-item-title class="ps-2">
-      {{ $t('spaceTemplate.label.editNavigation') }}
+      {{ $t('spaceTemplate.label.restoreDefaultPages') }}
     </v-list-item-title>
   </v-list-item>
 </template>
@@ -40,28 +40,24 @@ export default {
       default: null,
     },
   },
-  data: () => ({
-    site: null,
-  }),
   beforeDestroy() {
     this.$emit('loading', false);
   },
   methods: {
-    async openSiteNavigationDrawer() {
+    async restoreDefaultPages() {
       this.$emit('loading', true);
       try {
-        if (!this.site) {
-          this.site = await this.$siteService.getSite('group_template', this.spaceTemplate?.layout, {
-            expandNavigations: false,
-          });
-        }
-        document.dispatchEvent(new CustomEvent('open-site-navigation-drawer',{detail: {
-          siteName: this.site.name,
-          siteType: this.site.siteType,
-          siteId: this.site.siteId,
-          siteLabel: this.spaceTemplate?.name,
-          includeGlobal: false,
-        }}));
+        await this.$siteLayoutService.restoreSite({
+          siteType: 'group_template',
+          siteName: this.spaceTemplate.layout,
+          importMode: 'MERGE',
+          siteLayout: false,
+          sitePages: true,
+          siteNavigation: true,
+        });
+        this.$root.$emit('alert-message', window.vueI18nMessages['siteManagement.label.restoreSitePages.success'], 'success');
+      } catch (e) {
+        this.$root.$emit('alert-message', window.vueI18nMessages['siteManagement.label.restoreSitePages.error'], 'error');
       } finally {
         this.$emit('loading', false);
       }

--- a/layout-webapp/src/main/webapp/vue-app/site-navigation/initComponents.js
+++ b/layout-webapp/src/main/webapp/vue-app/site-navigation/initComponents.js
@@ -21,6 +21,7 @@ import SiteNavigation from './components/SiteNavigation.vue';
 import SiteNavigationButton from './components/SiteNavigationButton.vue';
 import SiteNavigationDrawersActions from './components/SiteNavigationDrawersActions.vue';
 import SpaceTemplateEditLayoutSpaceMenuItem from './components/SpaceTemplateEditLayoutSpaceMenuItem.vue';
+import SpaceTemplateRestoreDefaultPagesSpaceMenuItem from './components/SpaceTemplateRestoreDefaultPagesSpaceMenuItem.vue';
 import SpaceTemplateCreateListener from './components/SpaceTemplateCreateListener.vue';
 
 const components = {
@@ -28,6 +29,7 @@ const components = {
   'site-navigation-button': SiteNavigationButton,
   'site-navigation-drawers-actions': SiteNavigationDrawersActions,
   'site-navigation-space-template-manage-layout': SpaceTemplateEditLayoutSpaceMenuItem,
+  'site-navigation-space-template-restore-default-pages': SpaceTemplateRestoreDefaultPagesSpaceMenuItem,
   'site-navigation-space-template-create-listener': SpaceTemplateCreateListener,
 };
 

--- a/layout-webapp/src/main/webapp/vue-app/site-navigation/main.js
+++ b/layout-webapp/src/main/webapp/vue-app/site-navigation/main.js
@@ -55,10 +55,16 @@ extensionRegistry.registerExtension('space-templates', 'space-templates-item-act
   componentName: 'site-navigation-space-template-manage-layout',
 });
 
-extensionRegistry.registerExtension('space-templates', 'space-templates-main', {
-  rank: 10,
+extensionRegistry.registerExtension('space-templates', 'space-templates-item-action', {
+  rank: 25,
   name: 'manage-layout',
-  componentName: 'site-navigation-space-template-create-listener',
+  componentName: 'site-navigation-space-template-manage-layout',
+});
+
+extensionRegistry.registerExtension('space-templates', 'space-templates-item-action', {
+  rank: 55,
+  name: 'restore-default-pages',
+  componentName: 'site-navigation-space-template-restore-default-pages',
 });
 
 const appId = 'siteNavigation';
@@ -67,8 +73,11 @@ const appId = 'siteNavigation';
 const lang = eXo && eXo.env.portal.language || 'en';
 
 //should expose the locale ressources as REST API
-const url = `/layout/i18n/locale.portlet.SiteNavigation?lang=${lang}`;
-const i18nPromise = exoi18n.loadLanguageAsync(lang, url);
+const urls = [
+  `/layout/i18n/locale.portlet.SiteNavigation?lang=${lang}`,
+  `/layout/i18n/locale.portlet.SiteManagement?lang=${lang}`,
+];
+const i18nPromise = exoi18n.loadLanguageAsync(lang, urls);
 
 export function init(canManageSiteNavigation) {
   i18nPromise.then(i18n => {


### PR DESCRIPTION
Prior to this change, the Builtin Space Template Pages wasn't editable nor deletable (can only disable/enable the whole space Template). This change will allow to Restore Default Site Template Pages from Sources using UI. Thus, the navigation and page layout edition has been allowed in order to give more flexibility to admins.