### PR TITLE
fix: List only enabled site template when creating a site - MEED-9488 - Meeds-io/meeds#3480 

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/site-management/components/drawer/SiteFormDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/site-management/components/drawer/SiteFormDrawer.vue
@@ -278,7 +278,7 @@ export default {
         || !(/^[a-zA-Z0-9_-]*$/).test(this.siteName);
     },
     sortedTemplates() {
-      const siteTemplates = this.templates?.filter?.(t => t.name) || [];
+      const siteTemplates = this.templates?.filter?.(t => t.name && !t.disabled) || [];
       siteTemplates.sort((a, b) => this.$root.collator.compare(a.name.toLowerCase(), b.name.toLowerCase()));
       return siteTemplates;
     },


### PR DESCRIPTION
Before this change, when creating a site from the administration settings, all site templates were listed . This change will display only the enabled templates.

(cherry picked from commit d19bdd92680e3015d4543d6c72d7d17f7bbeb75f)