### PR TITLE
fix: Fix the zip file content after updating a page template - MEED-9486 - Meeds-io/meeds#3479  

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -172,9 +172,7 @@ export default {
         const pageTemplate = await this.$pageTemplateService.getPageTemplate(this.templateId, true);
         this.description = pageTemplate?.description || '';
         this.duplicate = duplicate;
-        if (this.duplicate) {
-          this.pageLayoutContent = pageTemplate.content;
-        }
+        this.pageLayoutContent = pageTemplate.content;
       }
       if (generateIllustration) {
         const parentElement = document.querySelector('.layout-sections-parent .layout-page-body').parentElement;


### PR DESCRIPTION
Before this change, the content of the page template is always null during template updates. This change will resolve this issue by setting the stored content.