### PR TITLE
fix: Transform branding properties to portletPreferences for sidebarLogin - meeds-io/MIPs#203 - MEED-9487

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/plugin/attachment/CmsPortletAttachmentPlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/attachment/CmsPortletAttachmentPlugin.java
@@ -1,0 +1,79 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.layout.plugin.attachment;
+
+import io.meeds.layout.service.LayoutAclService;
+import io.meeds.layout.service.PortletInstanceService;
+import jakarta.annotation.PostConstruct;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.attachment.AttachmentPlugin;
+import org.exoplatform.social.attachment.AttachmentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CmsPortletAttachmentPlugin extends AttachmentPlugin {
+
+  public static final String     OBJECT_TYPE = "cmsPortlet";
+
+  @Autowired
+  private LayoutAclService       layoutAclService;
+
+  @Autowired
+  private PortletInstanceService portletInstanceService;
+
+  @Autowired
+  private AttachmentService      attachmentService;
+
+  @PostConstruct
+  public void init() {
+    attachmentService.addPlugin(this);
+  }
+
+  @Override
+  public String getObjectType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean hasEditPermission(Identity userIdentity, String entityId) throws ObjectNotFoundException {
+    return userIdentity != null
+           && layoutAclService.isAdministrator(userIdentity.getUserId());
+  }
+
+  @Override
+  public boolean hasAccessPermission(Identity userIdentity, String entityId) throws ObjectNotFoundException {
+    return true;
+  }
+
+  @Override
+  public long getAudienceId(String objectId) throws ObjectNotFoundException {
+    return 0;
+  }
+
+  @Override
+  public long getSpaceId(String objectId) throws ObjectNotFoundException {
+    return 0;
+  }
+
+}

--- a/layout-service/src/main/java/io/meeds/layout/plugin/renderer/SidebarLoginPortletInstancePreferencePlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/renderer/SidebarLoginPortletInstancePreferencePlugin.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Service
-public class LoginFormPortletInstancePreferencePlugin  implements PortletInstancePreferencePlugin {
+public class SidebarLoginPortletInstancePreferencePlugin implements PortletInstancePreferencePlugin {
 
 
   private static final String    DATA_INIT_PREFERENCE_NAME   = "data.init";
@@ -38,7 +38,7 @@ public class LoginFormPortletInstancePreferencePlugin  implements PortletInstanc
 
   @Override
   public String getPortletName() {
-    return "LoginForm";
+    return "SidebarLogin";
   }
 
   @Override

--- a/layout-service/src/test/java/io/meeds/layout/plugin/attachment/CmsPortletAttachmentPluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/attachment/CmsPortletAttachmentPluginTest.java
@@ -1,0 +1,97 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.layout.plugin.attachment;
+
+import io.meeds.layout.plugin.translation.CmsPortletTranslationPlugin;
+import io.meeds.layout.service.LayoutAclService;
+import io.meeds.layout.service.PortletInstanceService;
+import lombok.SneakyThrows;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.attachment.AttachmentService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = {
+  CmsPortletAttachmentPlugin.class,
+})
+@ExtendWith(MockitoExtension.class)
+class CmsPortletAttachmentPluginTest {
+
+  @MockBean
+  private AttachmentService               attachmentService;
+
+  @MockBean
+  private LayoutAclService                layoutAclService;
+
+  @MockBean
+  private PortletInstanceService          portletInstanceService;
+
+  @Autowired
+  private CmsPortletAttachmentPlugin attachmentPlugin;
+
+  @Mock
+  private Identity                        userIdentity;
+
+
+  @Test
+  void getObjectType() {
+    assertEquals("cmsPortlet", attachmentPlugin.getObjectType());
+    assertEquals(CmsPortletTranslationPlugin.OBJECT_TYPE, attachmentPlugin.getObjectType());
+  }
+
+  @Test
+  @SneakyThrows
+  void hasEditPermission() {
+    assertFalse(attachmentPlugin.hasEditPermission(null, null));
+    assertFalse(attachmentPlugin.hasEditPermission(userIdentity, null));
+    when(userIdentity.getUserId()).thenReturn("test");
+    when(layoutAclService.isAdministrator(userIdentity.getUserId())).thenReturn(true);
+    assertTrue(attachmentPlugin.hasEditPermission(userIdentity, null));
+  }
+
+  @Test
+  @SneakyThrows
+  void hasAccessPermission() {
+    assertTrue(attachmentPlugin.hasAccessPermission(userIdentity, null));
+  }
+
+  @Test
+  @SneakyThrows
+  void getAudienceId() {
+    assertEquals(0l, attachmentPlugin.getAudienceId(null));
+  }
+
+  @Test
+  @SneakyThrows
+  void getSpaceId() {
+    assertEquals(0l, attachmentPlugin.getSpaceId(""));
+  }
+
+}

--- a/layout-service/src/test/java/io/meeds/layout/plugin/renderer/SidebarLoginFormPortletInstancePreferencePluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/renderer/SidebarLoginFormPortletInstancePreferencePluginTest.java
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.layout.plugin.renderer;
+
+import io.meeds.layout.model.PortletInstanceContext;
+import io.meeds.layout.model.PortletInstancePreference;
+import org.exoplatform.portal.pom.spi.portlet.Portlet;
+import org.exoplatform.portal.pom.spi.portlet.Preference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(classes = {
+    SidebarLoginPortletInstancePreferencePlugin.class,
+})
+@ExtendWith(MockitoExtension.class)
+public class SidebarLoginFormPortletInstancePreferencePluginTest {
+
+  private static final String OTHER_PREF_NAME = "name2";
+  private static final String SETTING_NAME = "name";
+  public static final String TRANSLATION_IDENTIFIER = "translationIdentifier";
+  private static final String    DATA_INIT_PREFERENCE_NAME   = "data.init";
+
+  @Autowired
+  private SidebarLoginPortletInstancePreferencePlugin sidebarLoginPortletInstancePreferencePlugin;
+
+  @Test
+  void getPortletName() {
+    assertEquals("SidebarLogin", sidebarLoginPortletInstancePreferencePlugin.getPortletName());
+  }
+
+  @Test
+  void generatePreferences() {
+    Map<String, Preference> map = new HashMap<>();
+    map.put(SETTING_NAME, new Preference(SETTING_NAME, "value", false));
+    map.put(OTHER_PREF_NAME, new Preference(OTHER_PREF_NAME, "value", false));
+    map.put(TRANSLATION_IDENTIFIER, new Preference(TRANSLATION_IDENTIFIER, "123456789", false));
+    Portlet preferences = new Portlet(map);
+    List<PortletInstancePreference> generatedPreferences = sidebarLoginPortletInstancePreferencePlugin.generatePreferences(null, preferences, new PortletInstanceContext());
+    assertNotNull(generatedPreferences);
+    assertEquals(1, generatedPreferences.size());
+    assertEquals(DATA_INIT_PREFERENCE_NAME, generatedPreferences.get(0).getName());
+  }
+
+}


### PR DESCRIPTION
Before this fix, siebarLogin portlet use Branding information for background image, alt text, title and subtitle With this it is not possible to update the background for a portlet without changing for all portlets.

This commit transforms branding properties into portletPreferences