### PR TITLE
fix: Fix the site label when editing navigation after upgrading from 6.5 to 7.0 - MEED-9495 - Meeds-io/meeds#3347

### DIFF
--- a/layout-webapp/src/main/webapp/WEB-INF/jsp/siteNavigation.jsp
+++ b/layout-webapp/src/main/webapp/WEB-INF/jsp/siteNavigation.jsp
@@ -32,7 +32,7 @@
   <div id="siteNavigation">
     <script type="text/javascript">
       eXo.env.portal.isAdministrator = <%=isAdministrator%>;
-      eXo.env.portal.siteLabel = '<%=rcontext.getSiteLabel()%>';
+      eXo.env.portal.siteLabel = '<%=rcontext.getSiteLabel() == null ? "" : rcontext.getSiteLabel()%>';
     </script>
   </div>
 </div>


### PR DESCRIPTION
This change will fix the site label when editing navigation after upgrading from 6.5 to 7.0.

(cherry picked from commit 41897dd2331a287cdc7a49c5f0effb8261a2ca4b)