### PR TITLE
fix: Open Site Template Preview When clicked - MEED-9489 - Meeds-io/meeds#3481

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-site-template/main.js
+++ b/layout-webapp/src/main/webapp/vue-app/common-site-template/main.js
@@ -19,3 +19,5 @@
 
 import './services.js';
 import './initComponents.js';
+
+import '../common-illustration/main.js';


### PR DESCRIPTION
Prior to this change, the Site Template Preview isn't opened due to missing Vue Components Loading. This change ensures to open the Site Template Preview when needed in Site Creation Form.