### PR TITLE
feat: Improve TranslationService API with Object Id of Type String - MEED-9632 - Meeds-io/MIPs#203

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/plugin/translation/CmsPortletTranslationPlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/translation/CmsPortletTranslationPlugin.java
@@ -51,22 +51,22 @@ public class CmsPortletTranslationPlugin extends TranslationPlugin {
   }
 
   @Override
-  public boolean hasEditPermission(long id, String username) throws ObjectNotFoundException {
+  public boolean hasEditPermission(String id, String username) throws ObjectNotFoundException {
     return layoutAclService.isAdministrator(username);
   }
 
   @Override
-  public boolean hasAccessPermission(long id, String username) throws ObjectNotFoundException {
+  public boolean hasAccessPermission(String id, String username) throws ObjectNotFoundException {
     return true;
   }
 
   @Override
-  public long getAudienceId(long templateId) throws ObjectNotFoundException {
+  public long getAudienceId(String templateId) throws ObjectNotFoundException {
     return 0;
   }
 
   @Override
-  public long getSpaceId(long templateId) throws ObjectNotFoundException {
+  public long getSpaceId(String templateId) throws ObjectNotFoundException {
     return 0;
   }
 

--- a/layout-service/src/test/java/io/meeds/layout/plugin/translation/CmsPortletTranslationPluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/translation/CmsPortletTranslationPluginTest.java
@@ -59,28 +59,28 @@ class CmsPortletTranslationPluginTest {
   @Test
   @SneakyThrows
   void hasEditPermission() {
-    assertFalse(translationPlugin.hasEditPermission(0l, null));
-    assertFalse(translationPlugin.hasEditPermission(0l, username));
+    assertFalse(translationPlugin.hasEditPermission("0", null));
+    assertFalse(translationPlugin.hasEditPermission("0", username));
     when(layoutAclService.isAdministrator(username)).thenReturn(true);
-    assertTrue(translationPlugin.hasEditPermission(0l, username));
+    assertTrue(translationPlugin.hasEditPermission("0", username));
   }
 
   @Test
   @SneakyThrows
   void hasAccessPermission() {
-    assertTrue(translationPlugin.hasAccessPermission(1, username));
+    assertTrue(translationPlugin.hasAccessPermission("1", username));
   }
 
   @Test
   @SneakyThrows
   void getAudienceId() {
-    assertEquals(0l, translationPlugin.getAudienceId(0l));
+    assertEquals(0l, translationPlugin.getAudienceId("0"));
   }
 
   @Test
   @SneakyThrows
   void getSpaceId() {
-    assertEquals(0l, translationPlugin.getSpaceId(0l));
+    assertEquals(0l, translationPlugin.getSpaceId("0"));
   }
 
 }


### PR DESCRIPTION
This change will enhance `TranslationService` by accepting the `objectId` of type `String` in addition to type `Long`.

(A change needed to fix the rebase)