### PR TITLE
fix: Fix the save button activation when saving page layout as a template - MEED-9801 - Meeds-io/meeds#3699

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -155,7 +155,7 @@ export default {
       };
     },
     disabled() {
-      return !this.title?.length || this.title.length > this.maxTitleLength || (this.description?.length && this.description.length > this.maxDescriptionLength);
+      return !this.title?.length || this.title.length > this.maxTitleLength || (this.description?.length && this.$utils.htmlToText(this.description).length > this.maxDescriptionLength);
     },
   },
   created() {


### PR DESCRIPTION
Before this change, when saving a page layout as a template and then adding a description longer than 88 characters, the save button was disabled, when it should have been disabled after 100 characters. This change resolves this issue.