### PR TITLE
fix: Allow to export portlet settings (attachment and translations) - MEED-9809 - meeds-io/meeds#3780

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/plugin/renderer/CMSPortletInstancePreferencePlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/renderer/CMSPortletInstancePreferencePlugin.java
@@ -1,0 +1,153 @@
+package io.meeds.layout.plugin.renderer;
+
+import io.meeds.layout.model.PortletInstanceContext;
+import io.meeds.layout.model.PortletInstancePreference;
+import io.meeds.layout.plugin.PortletInstancePreferencePlugin;
+import io.meeds.social.translation.model.TranslationField;
+import io.meeds.social.translation.service.TranslationService;
+import lombok.SneakyThrows;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.commons.file.model.FileItem;
+import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.commons.file.services.FileStorageException;
+import org.exoplatform.portal.config.model.Application;
+import org.exoplatform.portal.pom.spi.portlet.Portlet;
+import org.exoplatform.portal.pom.spi.portlet.Preference;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.attachment.AttachmentService;
+import org.exoplatform.social.attachment.model.ObjectAttachmentDetail;
+import org.exoplatform.social.attachment.model.ObjectAttachmentList;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CMSPortletInstancePreferencePlugin implements PortletInstancePreferencePlugin {
+  private static final Log LOG = ExoLogger.getLogger(SidebarLoginPortletInstancePreferencePlugin.class);
+
+  private static final String DATA_INIT_PREFERENCE_NAME = "data.init";
+
+  private static final String EXPORT_DATA_INIT_PREFERENCE_NAME = "export.data.init";
+
+  private static final String EXPORT_DATA_ALT_INIT_PREFERENCE_NAME = "export.data.alt.init";
+
+  private static final String EXPORT_DATA_TRANSLATION_INIT_PREFERENCE_NAME = "export.data.translation.init";
+
+  private static final String CMS_SETTING_PREFERENCE_NAME = "name";
+
+  @Autowired
+  private AttachmentService attachmentService;
+
+  @Autowired
+  private FileService fileService;
+
+  @Autowired
+  private TranslationService translationService;
+
+  public static final String OBJECT_TYPE = "cmsPortlet";
+
+  @Override
+  public String getPortletName() {
+    return "CMSPortlet";
+  }
+
+  @Override
+  @SneakyThrows
+  public List<PortletInstancePreference> generatePreferences(Application application,
+                                                             Portlet preferences,
+                                                             PortletInstanceContext portletInstanceContext) {
+    String settingName = getCmsSettingName(preferences);
+    List<PortletInstancePreference> result = new ArrayList<>();
+    preferences.forEach(preference -> {
+      if (!preference.getName().equals("name") &&
+          !preference.getName().equals(DATA_INIT_PREFERENCE_NAME)) {
+        result.add(new PortletInstancePreference(preference.getName(), preference.getValue()));
+      }
+    });
+    if (!StringUtils.isBlank(settingName)) {
+      if (portletInstanceContext.isExport()) {
+        //portlet is in export process
+        //we need to put background images and translations in preferences
+        result.addAll(computePreferencesToExport(settingName));
+      } else {
+        result.add(new PortletInstancePreference(DATA_INIT_PREFERENCE_NAME, settingName));
+      }
+    } else {
+
+      if (portletInstanceContext.isExport() && preferences.getPreference(DATA_INIT_PREFERENCE_NAME) != null) {
+        //portlet is in export process
+        //we need to put background images and translations in preferences
+        settingName = preferences.getPreference(DATA_INIT_PREFERENCE_NAME).getValue();
+        result.addAll(computePreferencesToExport(settingName));
+      }
+    }
+
+
+    return result;
+  }
+
+  private String getFileContent(String id) {
+    try {
+      FileItem
+          file =
+          fileService.getFile(Long.parseLong(id));
+      if (file == null) {
+        return null;
+      } else {
+        return Base64.encodeBase64String(file.getAsByte());
+      }
+    } catch (FileStorageException e) {
+      LOG.warn("Unable to read file with id=", id, e);
+      return null;
+    }
+  }
+
+  private String getCmsSettingName(Portlet preferences) {
+    if (preferences == null) {
+      return null;
+    }
+    Preference settingNamePreference = preferences.getPreference(CMS_SETTING_PREFERENCE_NAME);
+    return settingNamePreference == null ? null : settingNamePreference.getValue();
+  }
+
+  private List<PortletInstancePreference> computePreferencesToExport(String settingName) {
+    List<PortletInstancePreference> preferencesToExport = new ArrayList<>();
+
+    try {
+      JSONObject translationsJson = new JSONObject();
+      Map<String, TranslationField>
+          translations = translationService.getAllTranslationFields(OBJECT_TYPE, settingName);
+      translations.entrySet().forEach(entry -> {
+        String translationKey = entry.getKey();
+        TranslationField translationField = entry.getValue();
+        if (!translationField.getLabels().isEmpty()) {
+          translationsJson.put(translationKey, translationField.getLabels());
+        }
+      });
+      if (!translationsJson.isEmpty()) {
+        preferencesToExport.add(new PortletInstancePreference(EXPORT_DATA_TRANSLATION_INIT_PREFERENCE_NAME,
+                                                              translationsJson.toString()));
+      }
+    } catch (ObjectNotFoundException o) {
+      //nothing to do, no translations to copy
+    }
+
+    ObjectAttachmentList attachmentList = attachmentService.getAttachments(OBJECT_TYPE, settingName);
+    ObjectAttachmentDetail file = attachmentList == null || attachmentList.getAttachments() == null || attachmentList.getAttachments().size() == 0 ?
+                                  null :
+                                  attachmentList.getAttachments().getFirst();
+    if (file != null) {
+      String fileContent = getFileContent(file.getId());
+      preferencesToExport.add(new PortletInstancePreference(EXPORT_DATA_INIT_PREFERENCE_NAME, fileContent));
+      if (file.getAltText() != null) {
+        preferencesToExport.add(new PortletInstancePreference(EXPORT_DATA_ALT_INIT_PREFERENCE_NAME, file.getAltText()));
+      }
+    }
+    return preferencesToExport;
+  }
+}

--- a/layout-service/src/main/java/io/meeds/layout/plugin/renderer/LoginFormPortletInstancePreferencePlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/renderer/LoginFormPortletInstancePreferencePlugin.java
@@ -21,24 +21,15 @@ package io.meeds.layout.plugin.renderer;
 
 import io.meeds.layout.model.PortletInstanceContext;
 import io.meeds.layout.model.PortletInstancePreference;
-import io.meeds.layout.plugin.PortletInstancePreferencePlugin;
-import org.apache.commons.lang3.StringUtils;
+import lombok.SneakyThrows;
 import org.exoplatform.portal.config.model.Application;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
-import org.exoplatform.portal.pom.spi.portlet.Preference;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
-public class LoginFormPortletInstancePreferencePlugin  implements PortletInstancePreferencePlugin {
-
-
-  private static final String    DATA_INIT_PREFERENCE_NAME   = "data.init";
-
-  private static final String    CMS_SETTING_PREFERENCE_NAME = "name";
-
+public class LoginFormPortletInstancePreferencePlugin extends CMSPortletInstancePreferencePlugin {
 
   @Override
   public String getPortletName() {
@@ -46,22 +37,11 @@ public class LoginFormPortletInstancePreferencePlugin  implements PortletInstanc
   }
 
   @Override
+  @SneakyThrows
   public List<PortletInstancePreference> generatePreferences(Application application,
                                                              Portlet preferences,
                                                              PortletInstanceContext portletInstanceContext) {
-    String settingName = getCmsSettingName(preferences);
-    if (!StringUtils.isBlank(settingName)) {
-      return Collections.singletonList(new PortletInstancePreference(DATA_INIT_PREFERENCE_NAME, settingName));
-    } else {
-      return Collections.emptyList();
-    }
-  }
+    return super.generatePreferences(application, preferences, portletInstanceContext);
 
-  private String getCmsSettingName(Portlet preferences) {
-    if (preferences == null) {
-      return null;
-    }
-    Preference settingNamePreference = preferences.getPreference(CMS_SETTING_PREFERENCE_NAME);
-    return settingNamePreference == null ? null : settingNamePreference.getValue();
   }
 }

--- a/layout-service/src/main/java/io/meeds/layout/plugin/renderer/SidebarLoginPortletInstancePreferencePlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/renderer/SidebarLoginPortletInstancePreferencePlugin.java
@@ -1,18 +1,14 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
- *
  * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
- *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
@@ -21,45 +17,29 @@ package io.meeds.layout.plugin.renderer;
 
 import io.meeds.layout.model.PortletInstanceContext;
 import io.meeds.layout.model.PortletInstancePreference;
-import io.meeds.layout.plugin.PortletInstancePreferencePlugin;
-import org.apache.commons.lang3.StringUtils;
+import lombok.SneakyThrows;
 import org.exoplatform.portal.config.model.Application;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
-import org.exoplatform.portal.pom.spi.portlet.Preference;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
-public class SidebarLoginPortletInstancePreferencePlugin implements PortletInstancePreferencePlugin {
-
-  private static final String DATA_INIT_PREFERENCE_NAME = "data.init";
-
-  private static final String    CMS_SETTING_PREFERENCE_NAME = "name";
+public class SidebarLoginPortletInstancePreferencePlugin extends CMSPortletInstancePreferencePlugin {
 
   @Override
   public String getPortletName() {
     return "SidebarLogin";
+
   }
 
   @Override
+  @SneakyThrows
   public List<PortletInstancePreference> generatePreferences(Application application,
                                                              Portlet preferences,
                                                              PortletInstanceContext portletInstanceContext) {
-    String settingName = getCmsSettingName(preferences);
-    if (!StringUtils.isBlank(settingName)) {
-      return Collections.singletonList(new PortletInstancePreference(DATA_INIT_PREFERENCE_NAME, settingName));
-    } else {
-      return Collections.emptyList();
-    }
+    return super.generatePreferences(application, preferences, portletInstanceContext);
+
   }
 
-  private String getCmsSettingName(Portlet preferences) {
-    if (preferences == null) {
-      return null;
-    }
-    Preference settingNamePreference = preferences.getPreference(CMS_SETTING_PREFERENCE_NAME);
-    return settingNamePreference == null ? null : settingNamePreference.getValue();
-  }
 }

--- a/layout-service/src/test/java/io/meeds/layout/plugin/renderer/LoginFormPortletInstancePreferencePluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/renderer/LoginFormPortletInstancePreferencePluginTest.java
@@ -20,20 +20,32 @@ package io.meeds.layout.plugin.renderer;
 
 import io.meeds.layout.model.PortletInstanceContext;
 import io.meeds.layout.model.PortletInstancePreference;
+import io.meeds.social.translation.service.TranslationService;
+import lombok.SneakyThrows;
+import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
 import org.exoplatform.portal.pom.spi.portlet.Preference;
+import org.exoplatform.social.attachment.AttachmentService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = {
   LoginFormPortletInstancePreferencePlugin.class,
@@ -48,6 +60,21 @@ public class LoginFormPortletInstancePreferencePluginTest {
   @Autowired
   private LoginFormPortletInstancePreferencePlugin loginFormPortletInstancePreferencePlugin;
 
+  @MockBean
+  private TranslationService translationService;
+
+  @MockBean
+  private FileService fileService;
+
+  @MockBean
+  private AttachmentService attachmentService;
+
+  @BeforeEach
+  @SneakyThrows
+  public void setup() {
+    lenient().when(translationService.getAllTranslationFields(any(),any())).thenReturn(new HashMap<>());
+  }
+
   @Test
   void getPortletName() {
     assertEquals("LoginForm", loginFormPortletInstancePreferencePlugin.getPortletName());
@@ -61,8 +88,25 @@ public class LoginFormPortletInstancePreferencePluginTest {
     Portlet preferences = new Portlet(map);
     List<PortletInstancePreference> generatedPreferences = loginFormPortletInstancePreferencePlugin.generatePreferences(null, preferences, new PortletInstanceContext());
     assertNotNull(generatedPreferences);
+    assertEquals(2, generatedPreferences.size());
+    assertEquals(DATA_INIT_PREFERENCE_NAME, generatedPreferences.get(1).getName());
+  }
+
+  @SneakyThrows
+  @Test
+  void generatePreferencesWithComputeForExport() {
+    Map<String, Preference> map = new HashMap<>();
+    map.put(SETTING_NAME, new Preference(SETTING_NAME, "value", false));
+    map.put(OTHER_PREF_NAME, new Preference(OTHER_PREF_NAME, "value", false));
+
+    PortletInstanceContext portletInstanceContext = mock(PortletInstanceContext.class);
+    when(portletInstanceContext.isExport()).thenReturn(true);
+
+    Portlet preferences = new Portlet(map);
+    List<PortletInstancePreference> generatedPreferences = loginFormPortletInstancePreferencePlugin.generatePreferences(null, preferences, portletInstanceContext);
+    assertNotNull(generatedPreferences);
     assertEquals(1, generatedPreferences.size());
-    assertEquals(DATA_INIT_PREFERENCE_NAME, generatedPreferences.get(0).getName());
+    assertEquals("name2", generatedPreferences.get(0).getName());
   }
 
 }

--- a/layout-service/src/test/java/io/meeds/layout/plugin/renderer/SidebarLoginFormPortletInstancePreferencePluginTest.java
+++ b/layout-service/src/test/java/io/meeds/layout/plugin/renderer/SidebarLoginFormPortletInstancePreferencePluginTest.java
@@ -20,13 +20,17 @@ package io.meeds.layout.plugin.renderer;
 
 import io.meeds.layout.model.PortletInstanceContext;
 import io.meeds.layout.model.PortletInstancePreference;
+import io.meeds.social.translation.service.TranslationService;
+import org.exoplatform.commons.file.services.FileService;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
 import org.exoplatform.portal.pom.spi.portlet.Preference;
+import org.exoplatform.social.attachment.AttachmentService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +49,15 @@ public class SidebarLoginFormPortletInstancePreferencePluginTest {
   private static final String SETTING_NAME = "name";
   private static final String    DATA_INIT_PREFERENCE_NAME   = "data.init";
 
+  @MockBean
+  private TranslationService translationService;
+
+  @MockBean
+  private FileService fileService;
+
+  @MockBean
+  private AttachmentService                           attachmentService;
+
   @Autowired
   private SidebarLoginPortletInstancePreferencePlugin sidebarLoginPortletInstancePreferencePlugin;
 
@@ -61,8 +74,8 @@ public class SidebarLoginFormPortletInstancePreferencePluginTest {
     Portlet preferences = new Portlet(map);
     List<PortletInstancePreference> generatedPreferences = sidebarLoginPortletInstancePreferencePlugin.generatePreferences(null, preferences, new PortletInstanceContext());
     assertNotNull(generatedPreferences);
-    assertEquals(1, generatedPreferences.size());
-    assertEquals(DATA_INIT_PREFERENCE_NAME, generatedPreferences.get(0).getName());
+    assertEquals(2, generatedPreferences.size());
+    assertEquals(DATA_INIT_PREFERENCE_NAME, generatedPreferences.get(1).getName());
   }
 
 }


### PR DESCRIPTION
Before this fix, attachments and translation for logins portlets (sidebarlogin and loginForm) cannot be exported. This commit ensure to export this information and reread it at display

Resolves meeds-io/meeds#3780