### PR TITLE
 fix: update page template without losing content - MEED-9942 

### DIFF
--- a/layout-webapp/src/main/resources/locale/portlet/SiteNavigation_aro.properties
+++ b/layout-webapp/src/main/resources/locale/portlet/SiteNavigation_aro.properties
@@ -74,18 +74,12 @@ siteNavigation.label.enterUrl=ادخل الرابط
 siteNavigation.label.newTab=تبويب جديد
 siteNavigation.label.sameTab=نفس علامة التبويب
 siteNavigation.label.choosePage=اختر صفحة
-<<<<<<< HEAD
-<<<<<<< HEAD
 siteNavigation.label.chooseSite=من أي موقع
 siteNavigation.label.openSameTab=فتح في نفس علامة التبويب
-=======
 siteNavigation.label.chooseSite=From any site
 siteNavigation.label.openSameTab=افتح في نفس علامة التبويب
->>>>>>> d61dfac8 (Merge Translations)
-=======
 siteNavigation.label.chooseSite=من أي موقع
 siteNavigation.label.openSameTab=فتح في نفس علامة التبويب
->>>>>>> origin/develop
 siteNavigation.label.pageTemplate=حدد قالب الصفحة
 siteNavigation.label.blankTemplate=قوالب فارغة
 siteNavigation.label.defaultTemplate=القوالب الافتراضية

--- a/layout-webapp/src/main/webapp/vue-app/common-layout/components/drawer/EditPageDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-layout/components/drawer/EditPageDrawer.vue
@@ -218,7 +218,7 @@ export default {
   },
   created() {
     this.$root.$on('layout-page-properties-open', this.open);
-    if (document.body.computedStyleMap().get('--allPagesLightGrey')) {
+    if (document.body.computedStyleMap && document.body.computedStyleMap().get('--allPagesLightGrey')) {
       this.defaultBackgroundColor = document.body.computedStyleMap().get('--allPagesLightGrey')[0] || this.defaultBackgroundColor;
     }
   },

--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -127,6 +127,7 @@ export default {
     duplicate: null,
     templateId: null,
     pageLayoutContent: null,
+    editLayoutProperties: false,
   }),
   watch: {
     description() {
@@ -165,14 +166,17 @@ export default {
     this.$root.$off('layout-page-template-drawer-open', this.open);
   },
   methods: {
-    async open(template, duplicate, generateIllustration) {
+    async open(template, duplicate, generateIllustration, editLayoutProperties) {
       this.templateId = template.id || this.$root.pageTemplate?.id || null;
+      this.editLayoutProperties = editLayoutProperties;
       this.pageLayoutContent = template.content;
       if (this.templateId) {
         const pageTemplate = await this.$pageTemplateService.getPageTemplate(this.templateId, true);
         this.description = pageTemplate?.description || '';
         this.duplicate = duplicate;
-        this.pageLayoutContent = pageTemplate.content;
+        if (this.duplicate) {
+          this.pageLayoutContent = pageTemplate.content;
+        }
       }
       if (generateIllustration) {
         const parentElement = document.querySelector('.layout-sections-parent .layout-page-body').parentElement;
@@ -208,7 +212,9 @@ export default {
             .then(pageTemplate => {
               const newTemplate = (this.$root.pageTemplate && !this.$root.pageTemplate.name);
               pageTemplate.disabled = newTemplate ? false : pageTemplate.disabled;
-              pageTemplate.content = this.pageLayoutContent;
+              if (!this.editLayoutProperties) {
+                pageTemplate.content = this.pageLayoutContent;
+              }
               return this.$pageTemplateService.updatePageTemplate(pageTemplate)
                 .then(() => {
                   if (newTemplate) {

--- a/layout-webapp/src/main/webapp/vue-app/page-template/components/list/PageTemplateItemMenu.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-template/components/list/PageTemplateItemMenu.vue
@@ -60,7 +60,7 @@
           </v-list-item>
           <v-list-item
             dense
-            @click="$root.$emit('layout-page-template-drawer-open', pageTemplate)">
+            @click="$root.$emit('layout-page-template-drawer-open', pageTemplate, false, false, true)">
             <v-card
               color="transparent"
               min-width="15"


### PR DESCRIPTION
Updating a page template was failing since the content was emptied when we update the template properties.
The fix will update the content only when the operation is started from the layout editor, otherwise, when the template is updated from the template list, the content won't be changed. 