### PR TITLE
fix: schedule visibility date picker not showing in Add Node drawer -MEED-9983 - Meeds-io/meeds#3867

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-sites/components/site-navigation/SiteNavigationScheduleDatePickers.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-sites/components/site-navigation/SiteNavigationScheduleDatePickers.vue
@@ -28,6 +28,8 @@
     <div class="flex-grow-1 flex-shrink-1">
       <div class="d-flex full-width overflow-hidden">
         <date-picker
+          :attach="false"
+          top
           v-model="startScheduleDate"
           :min-value="minimumStartDate"
           class="scheduleStartDatePicker flex-grow-1 flex-shrink-1 input-width-full pa-0" />
@@ -38,6 +40,8 @@
       </div>
       <div class="d-flex full-width overflow-hidden">
         <date-picker
+          :attach="false"
+          top
           v-model="endScheduleDate"
           :min-value="minimumEndDate"
           class="scheduleEndDatePicker flex-grow-1 flex-shrink-1 input-width-full pa-0" />


### PR DESCRIPTION
Prior to this change, the schedule visibility date picker was not showing in the Add Node drawer. This issue occurred because the date picker was using the attach property, which prevented it from being displayed. This change sets the attach property to false, resolving the issue
