### PR TITLE
fix: prevent error during navigation item update - MEED-10280 - Meeds-io/meeds#4081

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-sites/components/site-navigation/SiteNavigationNodeDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-sites/components/site-navigation/SiteNavigationNodeDrawer.vue
@@ -411,7 +411,7 @@ export default {
         labels: this.labels
       };
       if (this.editMode) {
-        const pageRef = pageData?.pageRef ||  (this.elementType !== 'Group' ? this.navigationNode.pageKey?.ref || `${ this.navigationNode.pageKey.site.typeName}::${ this.navigationNode.pageKey.site.name}::${this.navigationNode.pageKey?.name}` : '');
+        const pageRef = pageData?.pageRef ||  (this.elementType !== 'Group' && this.navigationNode.pageKey ? this.navigationNode.pageKey?.ref || `${ this.navigationNode.pageKey.site.typeName}::${ this.navigationNode.pageKey.site.name}::${this.navigationNode.pageKey?.name}` : '');
         if (this.elementType === 'existingPage') {
           const pageRef = this.selectedPage?.pageRef;
           pageData = {


### PR DESCRIPTION

Prior to this change, `a TypeError: can't access property "site", this.navigationNode.pageKey is null` was thrown when attempting to update a navigation item type, which prevented the update from completing. This change adds proper null handling to prevent the error.