### PR TITLE
fix: edit home menu disappear after scrolling an element down - MEED-10340 - Meeds-io/meeds#4124

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/layout-editor/components/toolbar/Toolbar.vue
+++ b/layout-webapp/src/main/webapp/vue-app/layout-editor/components/toolbar/Toolbar.vue
@@ -86,7 +86,10 @@ export default {
     },
   },
   mounted() {
-    document.querySelector('#vuetify-apps').append(this.$el);
+    const container = document.querySelector('#vuetify-apps');
+    if (!container.hasChildNodes(this.$el)) {
+      container.append(this.$el);
+    }
   },
 };
 </script>


### PR DESCRIPTION
Before this change, when create spacex then edit layout of home and move an element to the bottom of the page, check display of edit home menu. To fix this issue, a check was added to ensure that the toolbar element is not already present inside the container before appending it. This prevents duplicate DOM insertions and stabilizes the layout behavior during rendering. As a result, the edit home menu should be available.