### PR TITLE
fix : Removes unecessary filterByPermissions in SiteRest.getSites - EXO-86349 - meeds-io/si#16

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-sites/components/site-navigation/SiteNavigationSiteSuggester.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-sites/components/site-navigation/SiteNavigationSiteSuggester.vue
@@ -119,7 +119,7 @@ export default {
     },
     getSites() {
       this.loadingSuggestions = true;
-      return this.$siteService.getSites(null, 'USER', null, true, true, false, false, false, null, true)
+      return this.$siteService.getSites(null, 'USER', null, true, true, false, false, false, null)
         .then(sites => {
           this.sites = sites || [];
         })

--- a/layout-webapp/src/main/webapp/vue-app/site-management/components/SiteManagement.vue
+++ b/layout-webapp/src/main/webapp/vue-app/site-management/components/SiteManagement.vue
@@ -97,7 +97,6 @@ export default {
       return this.$siteService.getSitesByFilter({
         siteType: 'PORTAL',
         excludeSpaceSites: true,
-        filterByPermissions: true,
         expand: 'canRestore',
       })
         .then(sites => this.sites = sites?.filter(s => !s?.properties?.IS_SPACE_PUBLIC_SITE) || [])


### PR DESCRIPTION
Before this fix, the endpoint to get sites and groups navigation have a field filterByPermissions with default value to false So, anonymous users where able to read all groups and sites navigations. This field is no more necessary as navigation must be served always respecting permissions This commit removes the fields

Resolves meeds-io/si#16