### PR TITLE
fix : Removes fields filterByPermissions in siteService.getSites - EXO-86349 - meeds-io/si#16

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-sites/components/site-navigation/SiteNavigationSiteSuggester.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-sites/components/site-navigation/SiteNavigationSiteSuggester.vue
@@ -119,7 +119,7 @@ export default {
     },
     getSites() {
       this.loadingSuggestions = true;
-      return this.$siteService.getSites(null, 'USER', null, true, true, false, false, false, null, true)
+      return this.$siteService.getSites(null, 'USER', null, true, true, false, false, false, null)
         .then(sites => {
           this.sites = sites || [];
         })

--- a/layout-webapp/src/main/webapp/vue-app/site-management/components/SiteManagement.vue
+++ b/layout-webapp/src/main/webapp/vue-app/site-management/components/SiteManagement.vue
@@ -97,7 +97,6 @@ export default {
       return this.$siteService.getSitesByFilter({
         siteType: 'PORTAL',
         excludeSpaceSites: true,
-        filterByPermissions: true,
         expand: 'canRestore',
       })
         .then(sites => this.sites = sites?.filter(s => !s?.properties?.IS_SPACE_PUBLIC_SITE) || [])


### PR DESCRIPTION
The field filterByPermissions have been removed in SitesRest.getSites. This commit ensure to remove it in js services which call this endpoint

Resolves meeds-io/si#16