### PR TITLE
fix: Fix page template form weird behavior when a space is filled while typing description field - EXO-87174 - Meeds-io/meeds#4171

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -76,7 +76,7 @@
             <rich-editor
               id="pageTemplateDescription"
               ref="pageTemplateDescriptionEditor"
-              v-model="description"
+              v-model="descriptionTranslations[lang]"
               :placeholder="$t('layout.templateDescriptionPlaceholder')"
               :max-length="maxDescriptionLength"
               :tag-enabled="false"
@@ -128,6 +128,7 @@ export default {
     templateId: null,
     pageLayoutContent: null,
     editLayoutProperties: false,
+    lang: eXo.env.portal.language,
   }),
   watch: {
     description() {
@@ -156,11 +157,12 @@ export default {
       };
     },
     disabled() {
-      return !this.title?.length || this.title.length > this.maxTitleLength || (this.description?.length && this.$utils.htmlToText(this.description).length > this.maxDescriptionLength);
+      return !this.title?.length || this.title.length > this.maxTitleLength || (this.descriptionTranslations[this.lang]?.length && this.$utils.htmlToText(this.descriptionTranslations[this.lang]).length > this.maxDescriptionLength);
     },
   },
   created() {
     this.$root.$on('layout-page-template-drawer-open', this.open);
+    this.descriptionTranslations[this.lang] = '';
   },
   beforeDestroy() {
     this.$root.$off('layout-page-template-drawer-open', this.open);

--- a/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/common-page-template/components/PageTemplateDrawer.vue
@@ -128,7 +128,7 @@ export default {
     templateId: null,
     pageLayoutContent: null,
     editLayoutProperties: false,
-    lang: eXo.env.portal.language,
+    lang: eXo.env.portal.defaultLanguage,
   }),
   watch: {
     description() {


### PR DESCRIPTION
Prior to this change, a weird behavior occurs on page template form when a space is filled while typing description field, this is caused by the rich editor value being synced through `description` while the translation drawer was driven by `descriptionTranslations`, leading to inconsistent state and unnecessary editor resets. 
After this commit, the description field is bound to `descriptionTranslations[lang]` and the current locale translation key is initialized and kept in sync with the drawer, avoiding editor data updates while typing and preserving cursor position.

Resolves Meeds-io/meeds#4171