### PR TITLE
fix: Improve mobile section column access up to md breakpoint - EXO-87567

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/DynamicSection.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/DynamicSection.vue
@@ -55,8 +55,8 @@ export default {
   }),
   computed: {
     isMobileColumns() {
-      return this.$vuetify.breakpoint.smAndDown
-        && this.container?.cssClass?.includes?.('layout-mobile-columns');
+      return ['xs', 'sm', 'md'].includes(this.$vuetify.breakpoint?.name)
+          && this.container?.cssClass?.includes?.('layout-mobile-columns');
     },
     isHiddenOnMobile() {
       return this.$vuetify.breakpoint.smAndDown

--- a/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/DynamicSection.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/DynamicSection.vue
@@ -55,8 +55,8 @@ export default {
   }),
   computed: {
     isMobileColumns() {
-      return ['xs', 'sm', 'md'].includes(this.$vuetify.breakpoint?.name)
-          && this.container?.cssClass?.includes?.('layout-mobile-columns');
+      return this.$vuetify.breakpoint.mdAndDown
+        && this.container?.cssClass?.includes?.('layout-mobile-columns');
     },
     isHiddenOnMobile() {
       return this.$vuetify.breakpoint.smAndDown


### PR DESCRIPTION
Prior to this change, the secondary column (right portlets in the space feed)  was not accessible on medium screens because the mobile section menu was not shown. This change makes the mobile menu available on md screens so users can access the secondary column.