### PR TITLE
fix: Improve mobile section column access up to md breakpoint - EXO-87567 (#517)

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/DynamicSection.vue
+++ b/layout-webapp/src/main/webapp/vue-app/page-layout/components/container/DynamicSection.vue
@@ -55,7 +55,7 @@ export default {
   }),
   computed: {
     isMobileColumns() {
-      return this.$vuetify.breakpoint.smAndDown
+      return this.$vuetify.breakpoint.mdAndDown
         && this.container?.cssClass?.includes?.('layout-mobile-columns');
     },
     isHiddenOnMobile() {


### PR DESCRIPTION
Prior to this change, the secondary column (right portlets in the space feed) was not accessible on medium screens because the mobile section menu was not shown. This change makes the mobile menu available on md screens so users can access the secondary column.