### PR TITLE
fix: Fix section template import redirection - EXO-87340

### DIFF
--- a/layout-webapp/src/main/webapp/vue-app/section-template/components/drawer/SectionTemplateDeserializeDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/section-template/components/drawer/SectionTemplateDeserializeDrawer.vue
@@ -149,7 +149,6 @@ export default {
           uploadId: this.uploadId,
         });
         this.importFinished = true;
-        this.$root.$emit('section-template-saved');
       } catch (error) {
         if (String(error).indexOf('databind.notMatchType') >= 0) {
           this.$root.$emit('alert-message', this.$t('sectionTemplates.label.exception.notMatchType'), 'error');

--- a/layout-webapp/src/main/webapp/vue-app/section-template/components/drawer/SectionTemplateDeserializeDrawer.vue
+++ b/layout-webapp/src/main/webapp/vue-app/section-template/components/drawer/SectionTemplateDeserializeDrawer.vue
@@ -148,6 +148,7 @@ export default {
           objectType: 'SectionTemplate',
           uploadId: this.uploadId,
         });
+        this.$root.$emit('section-templates-list-refresh');
         this.importFinished = true;
       } catch (error) {
         if (String(error).indexOf('databind.notMatchType') >= 0) {


### PR DESCRIPTION
Prior to this change, after importing section template, a redirection is done to the edit section template layout page which is not expected since we can have a multiple section templates import. After this commit, as for page template import case, we will remove the redirection after importing section templates and just refresh the section templates list in section template management table.