### PR TITLE
fix: Fix background images (section and app) being lost when exportin g/importing a page template and creating a page from it - EXO-87505

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/util/DatabindUtils.java
+++ b/layout-service/src/main/java/io/meeds/layout/util/DatabindUtils.java
@@ -89,6 +89,18 @@ public class DatabindUtils {
     if (layout == null) {
       return;
     }
+    attachmentService.deleteAttachments(LayoutBackgroundAttachmentPlugin.OBJECT_TYPE,
+                                        String.valueOf(pageTemplateId));
+    saveAppBackgroundImagesInternal(pageTemplateId, layout, attachmentService, userIdentityId);
+  }
+
+  private static void saveAppBackgroundImagesInternal(long pageTemplateId,
+                                                      LayoutModel layout,
+                                                      AttachmentService attachmentService,
+                                                      long userIdentityId) {
+    if (layout == null) {
+      return;
+    }
 
     String appBackgroundImage = layout.getAppBackgroundImage();
     if (appBackgroundImage != null && !appBackgroundImage.isEmpty()) {
@@ -113,7 +125,7 @@ public class DatabindUtils {
     }
     if (layout.getChildren() != null) {
       for (LayoutModel child : layout.getChildren()) {
-        saveAppBackgroundImages(pageTemplateId, child, attachmentService, userIdentityId);
+        saveAppBackgroundImagesInternal(pageTemplateId, child, attachmentService, userIdentityId);
       }
     }
   }
@@ -139,10 +151,9 @@ public class DatabindUtils {
       uploadResource.setMimeType("image/png");
       uploadResource.setStatus(UploadResource.UPLOADED_STATUS);
       uploadResource.setStoreLocation(tempFile.getPath());
-      attachmentService.deleteAttachments(LayoutBackgroundAttachmentPlugin.OBJECT_TYPE, String.valueOf(templateId));
       UploadedAttachmentDetail uploadedAttachmentDetail = new UploadedAttachmentDetail(uploadResource);
 
-      String objectId = "template_" + templateId + "_" + UUID.randomUUID();
+      String objectId = String.valueOf(templateId);
 
       attachmentService.saveAttachment(uploadedAttachmentDetail,
                                        LayoutBackgroundAttachmentPlugin.OBJECT_TYPE,


### PR DESCRIPTION
1. objectId mismatch in `DatabindUtils.saveAppBackgroundImage` : Attachments were saved under `objectId` "template_<id>_<uuid>" but buildBackgroundUrl referenced only `id`. 
The renderer queries metadata by objectId and found nothing, causing background images to silently resolve to broken URLs on any platform.

3. deleteAttachments called on every recursive node: saveAppBackgroundImage was deleting all attachments for the template on every node visit during tree recursion. With multiple background images in the layout tree (e.g. section + app), each node's save deleted the previous node's attachment, leaving only the last one saved.

Fixes:
- Use String.valueOf(templateId) as objectId consistently in both saveAttachment and buildBackgroundUrl so the metadata lookup always resolves.
- Extract recursion into saveAppBackgroundImagesInternal and call deleteAttachments only once in the public saveAppBackgroundImages entry point, before recursion begins. 