### PR TITLE
fix: Avoid NPE when page not found - EXO-88179 (#524)

### DIFF
--- a/layout-service/src/main/java/io/meeds/layout/plugin/attachment/LayoutBackgroundAttachmentPlugin.java
+++ b/layout-service/src/main/java/io/meeds/layout/plugin/attachment/LayoutBackgroundAttachmentPlugin.java
@@ -120,7 +120,7 @@ public class LayoutBackgroundAttachmentPlugin extends AttachmentPlugin {
       return null;
     } else {
       Page page = layoutService.getPage(pageId);
-      return page.getPageKey();
+      return page == null ? null : page.getPageKey();
     }
   }
 


### PR DESCRIPTION
Prior to this change, when a page is deleted, an NPE is thrown rather than returning null as Page Key. This change avoids the NPe and let the Parmission ACL return false when the Page Key is returned as null.

(cherry picked from commit 3e33dcb244081287de25ef41e1e3f65700026dae)